### PR TITLE
Rotation cleanup

### DIFF
--- a/DKRot.toc
+++ b/DKRot.toc
@@ -16,5 +16,13 @@ Localization\localization.lua
 # XML UI objects
 ui\Options.xml
 
+# Initialize variables we need everywhere
+init.lua
+
+# Rotation files
+rotations\blood.lua
+rotations\frost.lua
+rotations\unholy.lua
+
 # Core addon functionality
-DKRot.lua
+core.lua

--- a/DKRot.toc
+++ b/DKRot.toc
@@ -14,12 +14,16 @@ extlibs\LibStub\Libstub.lua
 Localization\localization.lua
 
 # XML UI objects
+ui\templates.xml
 ui\Options.xml
+ui\positions.xml
 
-# Initialize variables we need everywhere
+# Initialize variables we need everywhere, and load helper functions
 init.lua
+helpers.lua
 
 # Rotation files
+rotations\blank.lua
 rotations\blood.lua
 rotations\frost.lua
 rotations\unholy.lua

--- a/Localization/localization.lua
+++ b/Localization/localization.lua
@@ -46,11 +46,13 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    DKROT_OPTIONS_CDR_DISEASES_DD_BOTH = "Both Diseases (FF+BP)"
    DKROT_OPTIONS_CDR_DISEASES_DD_ONE = "One Disease (FF)"
    DKROT_OPTIONS_CDR_DISEASES_DD_NONE = "Diseaseless"
-   DKROT_OPTIONS_CDR_ROTATION = "Use in Rotation"
+   DKROT_OPTIONS_CDR_ROTATION = "Rotation"
+   DKROT_OPTIONS_CDR_USE_IN_ROTATION = "Use in Rotation"
    DKROT_OPTIONS_CDR_RP = "Runic Power"
    DKROT_OPTIONS_CDR_MOVEALT_INTERRUPT = "Show Interrupt Icon"
    DKROT_OPTIONS_CDR_MOVEALT_AOE = "Show AOE Icon"
    DKROT_OPTIONS_CDR_MOVEALT_DND = "Show DnD Icon"
+   DKROT_OPTIONS_CDR_USEHOW = "Maintain Horn of Winter buff"
    DKROT_OPTIONS_CDR_ALT_ROT = "Use Alternative Rotation"
    DKROT_OPTIONS_CDR_ALT_ROT_UNHOLY = "Festerblight"
    DKROT_OPTIONS_CDR_ALT_ROT_FROST = "Dual-weild"
@@ -93,6 +95,8 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    DKROT_OPTIONS_DT_THREAT_HEALTH = "Show Health Bars"
    DKROT_OPTIONS_DT_DOTS = "Track DOTs"
    DKROT_OPTIONS_DT_TRANS = "Trans. (0-1)"
+
+   DKROT_OPTIONS_POSITION = "Position"
 
    DKROT_ABOUT = "About"
    DKROT_ABOUT_BODY = "Have Questions? Suggestions? or just want more information?<br/>Leave a comment on Curse.com"

--- a/UI/Options.xml
+++ b/UI/Options.xml
@@ -1,49 +1,4 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
-
-   <CheckButton name="DKROT_CheckButtonTemplate" virtual="true" inherits="InterfaceOptionsBaseCheckButtonTemplate">
-      <Layers>
-         <Layer level="ARTWORK">
-            <FontString name="$Parent_Text" inherits="GameFontHighlight">
-               <Anchors><Anchor point="LEFT" relativePoint="RIGHT"><Offset><AbsDimension x="0" y="1"/></Offset></Anchor></Anchors>
-            </FontString>
-         </Layer>
-      </Layers>
-      <Scripts>
-         <OnClick>DKROT_OptionsOkay();</OnClick>
-      </Scripts>
-   </CheckButton>
-
-   <Button name="DKROT_DropDownTemplate" virtual="true" inherits="UIDropDownMenuTemplate">
-      <Layers>
-         <Layer level="ARTWORK">
-            <FontString name="$Parent_Text" inherits="GameFontHighlight">
-               <Anchors><Anchor point="BOTTOMLEFT" relativePoint="TOPLEFT"><Offset><AbsDimension x="20" y="2"/></Offset></Anchor></Anchors>
-            </FontString>
-         </Layer>
-      </Layers>
-   </Button>
-
-   <EditBox name="DKROT_EditBoxTemplate" virtual="true" autoFocus="false" inherits="InputBoxTemplate">
-         <Size><AbsDimension x="25" y="28"/></Size>
-         <Layers>
-            <Layer level="ARTWORK">
-               <FontString name="$Parent_Text" inherits="GameFontHighlight">
-                 <Anchors><Anchor point="LEFT" relativePoint="RIGHT"><Offset><AbsDimension x="5" y="1"/></Offset></Anchor></Anchors>
-               </FontString>
-            </Layer>
-         </Layers>
-         <Scripts>
-            <OnEnterPressed>
-               DKROT_OptionsOkay()
-               self:ClearFocus()
-            </OnEnterPressed>
-            <OnEscapePressed>
-               DKROT_OptionsOkay()
-               self:ClearFocus()
-            </OnEscapePressed>
-         </Scripts>
-      </EditBox>
-
    <Frame name="DKROT_Options">
       <Scripts>
          <OnLoad>
@@ -108,7 +63,7 @@
             </Scripts>
          </CheckButton>
          
-         <!--Range -->
+         <!-- Range -->
          <CheckButton name="DKROT_FramePanel_Range" inherits="DKROT_CheckButtonTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_CDS"><Offset><AbsDimension x="0" y="-35"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -118,7 +73,7 @@
             </Scripts>
          </CheckButton>
          
-         <!--Rune -->
+         <!-- Rune -->
          <CheckButton name="DKROT_FramePanel_Rune" inherits="DKROT_CheckButtonTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_Range"><Offset><AbsDimension x="0" y="-35"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -128,7 +83,7 @@
             </Scripts>
          </CheckButton>
          
-         <!--RuneBars -->
+         <!-- RuneBars -->
          <CheckButton name="DKROT_FramePanel_RuneBars" inherits="DKROT_CheckButtonTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_Rune"><Offset><AbsDimension x="0" y="-35"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -138,7 +93,7 @@
             </Scripts>
          </CheckButton>
          
-         <!--Rune DD-->
+         <!-- Rune DD-->
          <Button name="DKROT_FramePanel_Rune_DD" inherits="DKROT_DropDownTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_RuneBars" ><Offset><AbsDimension x="-16" y="-45"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -149,7 +104,7 @@
             </Scripts>
          </Button>
          
-         <!--RP -->
+         <!-- RP -->
          <CheckButton name="DKROT_FramePanel_RP" inherits="DKROT_CheckButtonTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_Rune_DD"><Offset><AbsDimension x="15" y="-35"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -159,7 +114,7 @@
             </Scripts>
          </CheckButton>
          
-         <!--Disease -->
+         <!-- Disease -->
          <CheckButton name="DKROT_FramePanel_Disease" inherits="DKROT_CheckButtonTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_RP"><Offset><AbsDimension x="0" y="-35"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -168,8 +123,6 @@
                </OnLoad>
             </Scripts>
          </CheckButton>
-         
-         
          
          <!-- Lock -->
          <CheckButton name="DKROT_FramePanel_Locked" inherits="DKROT_CheckButtonTemplate">
@@ -191,7 +144,7 @@
             </Scripts>
          </CheckButton>
 
-         <!--View Dropdown -->
+         <!-- View Dropdown -->
          <Button name="DKROT_FramePanel_ViewDD" inherits="DKROT_DropDownTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_LockedPieces" ><Offset><AbsDimension x="-15" y="-50"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -202,7 +155,7 @@
             </Scripts>
          </Button>
 
-         <!--Scale -->
+         <!-- Scale -->
          <EditBox name="DKROT_FramePanel_Scale" inherits="DKROT_EditBoxTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_ViewDD" relativePoint="BOTTOMLEFT"><Offset><AbsDimension x="25" y="-5"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -212,7 +165,7 @@
             </Scripts>
          </EditBox>
 
-         <!--Trans -->
+         <!-- Trans -->
          <EditBox name="DKROT_FramePanel_NormalTrans" inherits="DKROT_EditBoxTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_Scale" relativePoint="BOTTOMLEFT"><Offset><AbsDimension x="0" y="-5"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -231,7 +184,7 @@
             </Scripts>
          </EditBox>
          
-         <!--Trans Combat -->
+         <!-- Trans Combat -->
          <EditBox name="DKROT_FramePanel_CombatTrans" inherits="DKROT_EditBoxTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_Trans" relativePoint="BOTTOMLEFT"><Offset><AbsDimension x="0" y="-5"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -241,7 +194,7 @@
             </Scripts>
          </EditBox>
 
-         <!--Reset -->
+         <!-- Reset -->
          <Button name="DKROT_FramePanel_Reset" inherits="UIPanelButtonTemplate"  Text="DKROT_OPTIONS_RESET">
             <Size><AbsDimension x="120" y="22"/></Size>
             <Anchors><Anchor point="BOTTOMLEFT"><Offset><AbsDimension x="15" y="15" /></Offset></Anchor></Anchors>
@@ -250,7 +203,7 @@
             </Scripts>
          </Button>
 
-         <!--Location Reset -->
+         <!-- Location Reset -->
          <Button name="DKROT_FramePanel_LocationReset" inherits="UIPanelButtonTemplate"  Text="DKROT_OPTIONS_RESETLOCATION">
             <Size><AbsDimension x="120" y="22"/></Size>
             <Anchors><Anchor point="BOTTOMRIGHT"><Offset><AbsDimension x="-15" y="15" /></Offset></Anchor></Anchors>
@@ -283,14 +236,14 @@
          </Layer>
          
          <Layer level="ARTWORK">
-            <FontString name="DKROT_CDRPanel_Rotation_Title" inherits="GameFontHighlight" text="DKROT_OPTIONS_CDR_ROTATION">
+            <FontString name="DKROT_CDRPanel_Rotation_Title" inherits="GameFontHighlight" text="DKROT_OPTIONS_CDR_USE_IN_ROTATION">
                <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_CDRPanel" relativePoint="TOPRIGHT"><Offset><AbsDimension x="-200" y="-40" /></Offset></Anchor></Anchors>
             </FontString>
          </Layer>
       </Layers>
 
       <Frames>
-         <!--Diseases DD-->
+         <!-- Diseases DD -->
          <Button name="DKROT_CDRPanel_Diseases_DD" inherits="DKROT_DropDownTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_CDRPanel_DD_Title" ><Offset><AbsDimension x="-16" y="-40"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -299,7 +252,7 @@
                   UIDropDownMenu_SetWidth(self, 160, 5)
                </OnLoad>
             </Scripts>
-            </Button>
+         </Button>
          
          <!-- Interrupt  Icon-->
          <CheckButton name="DKROT_CDRPanel_MoveAltInterrupt" inherits="DKROT_CheckButtonTemplate">
@@ -311,7 +264,7 @@
             </Scripts>
          </CheckButton>
          
-         <!-- AOE  Icon-->
+         <!-- AOE Icon -->
          <CheckButton name="DKROT_CDRPanel_MoveAltAOE" inherits="DKROT_CheckButtonTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_CDRPanel_MoveAltInterrupt"><Offset><AbsDimension x="0" y="-35"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -321,7 +274,7 @@
             </Scripts>
          </CheckButton>
 
-         <!-- AOE  Icon-->
+         <!-- DND Icon -->
          <CheckButton name="DKROT_CDRPanel_MoveAltDND" inherits="DKROT_CheckButtonTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_CDRPanel_MoveAltAOE"><Offset><AbsDimension x="0" y="-35"/></Offset></Anchor></Anchors>
             <Scripts>
@@ -331,10 +284,26 @@
             </Scripts>
          </CheckButton>
 
-         <!-- Alternative Rotation-->
-         <CheckButton name="DKROT_CDRPanel_AltRot" inherits="DKROT_CheckButtonTemplate">
+         <!-- Horn of Winter -->
+         <CheckButton name="DKROT_CDRPanel_UseHoW" inherits="DKROT_CheckButtonTemplate">
             <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_CDRPanel_MoveAltDND"><Offset><AbsDimension x="0" y="-35"/></Offset></Anchor></Anchors>
+            <Scripts>
+               <OnLoad>
+                  DKROT_CDRPanel_UseHoW_Text:SetText(DKROT_OPTIONS_CDR_USEHOW)
+               </OnLoad>
+            </Scripts>
          </CheckButton>
+
+         <!-- Rotation to use -->
+         <Button name="DKROT_CDRPanel_Rotation" inherits="DKROT_DropDownTemplate">
+            <Anchors><Anchor point="TOPLEFT" relativeTo="DKROT_CDRPanel_UseHoW"><Offset><AbsDimension x="-16" y="-45"/></Offset></Anchor></Anchors>
+            <Scripts>
+               <OnLoad>
+                  DKROT_CDRPanel_Rotation_Text:SetText(DKROT_OPTIONS_CDR_ROTATION)
+                  UIDropDownMenu_SetWidth(self, 200, 5)
+               </OnLoad>
+            </Scripts>
+         </Button>
          
          <!-- Rotation Option-->
          <Frame name="DKROT_CDRPanel_Rotation" toplevel="true" parent="DKROT_CDRPanel" frameStrata="DIALOG">

--- a/UI/Options.xml
+++ b/UI/Options.xml
@@ -9,7 +9,7 @@
          </Layer>
       </Layers>
       <Scripts>
-         <OnClick>DKROT:OptionsOkay();</OnClick>
+         <OnClick>DKROT_OptionsOkay();</OnClick>
       </Scripts>
    </CheckButton>
 
@@ -34,11 +34,11 @@
          </Layers>
          <Scripts>
             <OnEnterPressed>
-               DKROT:OptionsOkay()
+               DKROT_OptionsOkay()
                self:ClearFocus()
             </OnEnterPressed>
             <OnEscapePressed>
-               DKROT:OptionsOkay()
+               DKROT_OptionsOkay()
                self:ClearFocus()
             </OnEscapePressed>
          </Scripts>
@@ -48,7 +48,7 @@
       <Scripts>
          <OnLoad>
             self.name = "DKRot"
-            self.okay = function() DKROT:OptionsOkay(); end
+            self.okay = function() DKROT_OptionsOkay(); end
             self.default = function() DKROT:SetDefaults(); end
          </OnLoad>
          <OnShow>

--- a/UI/positions.xml
+++ b/UI/positions.xml
@@ -1,0 +1,130 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/">
+   <Frame name="DKROT_PositionPanel">
+      <Scripts>
+         <OnLoad>
+            self.name = DKROT_OPTIONS_POSITION
+            self.parent = "DKRot"
+         </OnLoad>
+      </Scripts>
+
+      <Layers>
+         <Layer level="ARTWORK">
+            <FontString name="DKROT_PositionPanel_Title" inherits="GameFontNormalLarge" text="DKROT_ADDONNAME">
+               <Anchors>
+                  <Anchor point="TOPLEFT">
+                     <Offset>
+                        <AbsDimension x="15" y="-15" />
+                     </Offset>
+                  </Anchor>
+               </Anchors>
+            </FontString>
+         </Layer>
+      </Layers>
+
+      <Frames>
+         <Button name="DKROT_PositionPanel_Element" inherits="DKROT_DropDownTemplate">
+            <Anchors>
+               <Anchor point="TOPLEFT" relativeTo="DKROT_PositionPanel_Title">
+                  <Offset>
+                     <AbsDimension x="-15" y="-45" />
+                  </Offset>
+               </Anchor>
+            </Anchors>
+            <Scripts>
+               <OnLoad>
+                  UIDropDownMenu_SetWidth(self, 200, 5)
+               </OnLoad>
+            </Scripts>
+         </Button>
+
+         <Slider name="DKROT_PositionPanel_Width" inherits="DKROT_SliderTemplate"
+            minValue="0" maxValue="500" valueStep="1" stepsPerPage="10">
+            <Layers>
+               <Layer level="ARTWORK">
+                  <FontString name="$parent_Title" inherits="GameFontHighlight" text="Width">
+                     <Anchors>
+                        <Anchor point="BOTTOM" relativePoint="TOP"/>
+                     </Anchors>
+                  </FontString>
+               </Layer>
+            </Layers>
+            <Anchors>
+               <Anchor point="TOPLEFT" relativeTo="DKROT_PositionPanel_Element">
+                  <OffSet>
+                     <AbsDimension x="15" y="-55" />
+                  </OffSet>
+               </Anchor>
+            </Anchors>
+            <Scripts>
+               <OnValueChanged>
+                  getglobal(self:GetName() .. "_Value"):SetText(math.floor(value))
+               </OnValueChanged>
+            </Scripts>
+         </Slider>
+
+         <Slider name="DKROT_PositionPanel_Height" inherits="DKROT_SliderTemplate"
+            minValue="0" maxValue="500" valueStep="1" stepsPerPage="10">
+            <Layers>
+               <Layer level="ARTWORK">
+                     <FontString name="$parent_Title" inherits="GameFontHighlight" text="Height">
+                     <Anchors>
+                        <Anchor point="BOTTOM" relativePoint="TOP"/>
+                     </Anchors>
+                  </FontString>
+               </Layer>
+            </Layers>
+            <Anchors>
+               <Anchor point="LEFT" relativePoint="RIGHT" relativeTo="DKROT_PositionPanel_Width">
+                  <OffSet>
+                     <AbsDimension x="50" y="0" />
+                  </OffSet>
+               </Anchor>
+            </Anchors>
+            <Scripts>
+               <OnValueChanged>
+                  getglobal(self:GetName() .. "_Value"):SetText(math.floor(value))
+               </OnValueChanged>
+            </Scripts>
+         </Slider>
+
+         <Slider name="DKROT_PositionPanel_Scale" inherits="DKROT_SliderTemplate"
+            minValue="0" maxValue="10" valueStep="1" stepsPerPage="2">
+            <Layers>
+               <Layer level="ARTWORK">
+                  <FontString name="$parent_Title" inherits="GameFontHighlight" text="Scale">
+                     <Anchors>
+                        <Anchor point="BOTTOM" relativePoint="TOP"/>
+                     </Anchors>
+                  </FontString>
+               </Layer>
+            </Layers>
+            <Anchors>
+               <Anchor point="TOPLEFT" relativeTo="DKROT_PositionPanel_Width">
+                  <OffSet>
+                     <AbsDimension x="0" y="-55" />
+                  </OffSet>
+               </Anchor>
+            </Anchors>
+            <Scripts>
+               <OnValueChanged>
+                  DKROT_PositionUpdate()
+                  local val = tonumber(string.format("%.1f", value))
+                  getglobal(self:GetName() .. "_Value"):SetText(math.floor(val))
+               </OnValueChanged>
+            </Scripts>
+         </Slider>
+
+         <!--
+         <EditBox name="DKROT_PositionPanel_EditX" inherits="DKROT_SliderEditBoxTemplate">
+            <Anchors>
+               <Anchor point="TOPLEFT" relativeTo="DKROT_PositionPanel_SliderX">
+                  <OffSet>
+                     <AbsDimension x="15" y="-35" />
+                  </OffSet>
+               </Anchor>
+            </Anchors>
+         </EditBox>
+         -->
+      </Frames>
+   </Frame>
+</Ui>

--- a/UI/templates.xml
+++ b/UI/templates.xml
@@ -1,0 +1,111 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/">
+   <CheckButton name="DKROT_CheckButtonTemplate" virtual="true" inherits="InterfaceOptionsBaseCheckButtonTemplate">
+      <Layers>
+         <Layer level="ARTWORK">
+            <FontString name="$Parent_Text" inherits="GameFontHighlight">
+               <Anchors><Anchor point="LEFT" relativePoint="RIGHT"><Offset><AbsDimension x="0" y="1"/></Offset></Anchor></Anchors>
+            </FontString>
+         </Layer>
+      </Layers>
+      <Scripts>
+         <OnClick>DKROT_OptionsOkay();</OnClick>
+      </Scripts>
+   </CheckButton>
+
+   <Button name="DKROT_DropDownTemplate" virtual="true" inherits="UIDropDownMenuTemplate">
+      <Layers>
+         <Layer level="ARTWORK">
+            <FontString name="$Parent_Text" inherits="GameFontHighlight">
+               <Anchors><Anchor point="BOTTOMLEFT" relativePoint="TOPLEFT"><Offset><AbsDimension x="20" y="2"/></Offset></Anchor></Anchors>
+            </FontString>
+         </Layer>
+      </Layers>
+   </Button>
+
+   <EditBox name="DKROT_EditBoxTemplate" virtual="true" autoFocus="false" inherits="InputBoxTemplate">
+      <Size>
+         <AbsDimension x="25" y="28"/>
+      </Size>
+      <Layers>
+         <Layer level="ARTWORK">
+            <FontString name="$Parent_Text" inherits="GameFontHighlight">
+               <Anchors>
+                  <Anchor point="LEFT" relativePoint="RIGHT">
+                     <Offset>
+                        <AbsDimension x="5" y="1"/>
+                     </Offset>
+                  </Anchor>
+               </Anchors>
+            </FontString>
+         </Layer>
+      </Layers>
+      <Scripts>
+         <OnEnterPressed>
+            DKROT_OptionsOkay()
+            self:ClearFocus()
+         </OnEnterPressed>
+         <OnEscapePressed>
+            DKROT_OptionsOkay()
+            self:ClearFocus()
+         </OnEscapePressed>
+      </Scripts>
+   </EditBox>
+
+   <Slider name="DKROT_SliderTemplate" virtual="true" inherits="Slider" orientation="HORIZONTAL">
+      <Size x="250" y="20" />
+      <Backdrop bgFile="Interface\Buttons\UI-SliderBar-Background" edgeFile="Interface\Buttons\UI-SliderBar-Border" tile="true">
+         <EdgeSize val="8"/>
+         <TileSize val="8"/>
+         <BackgroundInsets left="3" right="3" top="6" bottom="6"/>
+      </Backdrop>
+      <ThumbTexture name="$parentThumb" file="Interface\Buttons\UI-SliderBar-Button-Horizontal">
+         <Size x="32" y="32"/>
+      </ThumbTexture>
+      <Layers>
+         <Layer level="ARTWORK">
+            <FontString name="$parent_Value" inherits="GameFontHighlight">
+               <Anchors>
+                  <Anchor point="TOP" relativePoint="BOTTOM"/>
+               </Anchors>
+            </FontString>
+
+            <FontString name="$parent_Low" inherits="GameFontHighlightSmall" text="">
+               <Anchors>
+                  <Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT">
+                     <Offset>
+                        <AbsDimension x="-4" y="3"/>
+                     </Offset>
+                  </Anchor>
+               </Anchors>
+            </FontString>
+
+            <FontString name="$parent_High" inherits="GameFontHighlightSmall" text="">
+               <Anchors>
+                  <Anchor point="TOPRIGHT" relativePoint="BOTTOMRIGHT">
+                     <Offset>
+                        <AbsDimension x="4" y="3"/>
+                     </Offset>
+                  </Anchor>
+               </Anchors>
+            </FontString>
+         </Layer>
+      </Layers>
+      <Scripts>
+         <OnLoad>
+            local min, max = self:GetMinMaxValues()
+            getglobal(self:GetName() .. "_Low"):SetText(min)
+            getglobal(self:GetName() .. "_High"):SetText(max)
+         </OnLoad>
+      </Scripts>
+   </Slider>
+
+   <!--
+   <EditBox name="DKROT_SliderEditBoxTemplate" virtual="true">
+      <Size x="70" y="14" />
+      <Backdrop bgFile="Interface\ChatFrame\ChatFrameBackground" edgeFile="Interface\ChatFrame\ChatFrameBackground" tile="true">
+         <EdgeSize val="1" />
+         <TileSize val="5" />
+      </Backdrop>
+   </EditBox>
+   -->
+</Ui>

--- a/core.lua
+++ b/core.lua
@@ -1,18 +1,17 @@
 local debugg = false
 if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    if debugg then print("DKROT:Starting")end
-   DKROT_VERSION = GetAddOnMetadata("DKRot", "Version")
+   local _, DKROT = ...
 
    -----Create Main Frame-----
-   local DKROT = CreateFrame("Button", "DKROT", UIParent)
-   DKROT:SetWidth(94)
-   DKROT:SetHeight(68)
-   DKROT:SetFrameStrata("BACKGROUND")
+   DKROT.MainFrame = CreateFrame("Button", "DKROT", UIParent)
+   DKROT.MainFrame:SetWidth(94)
+   DKROT.MainFrame:SetHeight(68)
+   DKROT.MainFrame:SetFrameStrata("BACKGROUND")
 
    -----Locals-----
-   --Constants
+   -- Constants
    local PLAYER_NAME, PLAYER_RACE, PLAYER_PRESENCE = UnitName("player"), select(2, UnitRace("player")), 0
-   local SPEC_UNKNOWN, SPEC_BLOOD, SPEC_FROST, SPEC_UNHOLY = 0, 1, 2, 3
    local BBUUFF, BBFFUU, UUBBFF, UUFFBB, FFUUBB, FFBBUU = 1, 2, 3, 4, 5, 6
    local DISEASE_BOTH, DISEASE_ONE, DISEASE_NONE = 2, 1, 0
    local THREAT_OFF, THREAT_HEALTH, THREAT_ANALOG, THREAT_DIGITAL = 0, 0.1, 1, 99
@@ -28,7 +27,6 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    }
 
    --Variables
-   local DTspells
    local loaded, mutex = false, false
    local mousex, mousey
    local font = 'Interface\\AddOns\\DKRot\\Font.ttf'
@@ -37,7 +35,6 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    local simtime = 0
    local bsamount = 0
    local GCD, curtime, launchtime = 0, 0, 0
-   local Current_Spec = SPEC_UNKNOWN
    local updatetimer = 0
 
    if debugg then print("DKROT:Locals Done")end
@@ -46,7 +43,6 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    local LBF = LibStub("LibButtonFacade", true)
    local MSQ = LibStub("Masque", true)
    if LBF or MSQ then
-      print("Masque or ButtonFacade detected")
       function DKROT:OnSkin(skin, gloss, backdrop, _, _, colours)
          DKROT_Settings.lbf[1] = skin
          DKROT_Settings.lbf[2] = gloss
@@ -55,11 +51,10 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
    end
 
-   local spells
    function DKROT:LoadSpells()
-      if spells ~= nil then wipe(spells) end
-      spells = {}
-      spells = {
+      if DKROT.spells ~= nil then wipe(DKROT.spells) end
+      DKROT.spells = {}
+      DKROT.spells = {
          ["Anti-Magic Shell"] = GetSpellInfo(48707), --lvl68
          ["Army of the Dead"] = GetSpellInfo(42650), --lvl80
          ["Blood Boil"] = GetSpellInfo(50842), --lvl56
@@ -148,133 +143,132 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          ["BloodElf"] = GetSpellInfo(28730),--Arcane Torrent
          ["Goblin"] = GetSpellInfo(69070),--Rocket Jump
       }
-      DTspells = { -- ID, Duration, Effected by talent
-         [spells["Frost Fever"]] = {55095, 30},
-         [spells["Blood Plague"]] = {55078, 30},
-         [spells["Death and Decay"]] = {43265, 10},
-         [spells["Defile"]] = {152280, 10},
-         [spells["Necrotic Plague"]] = {152281, 30},
-         [spells["Chilblains"]] = {50435, 10},
+      DKROT.DTspells = { -- ID, Duration, Effected by talent
+         [DKROT.spells["Frost Fever"]] = {55095, 30},
+         [DKROT.spells["Blood Plague"]] = {55078, 30},
+         [DKROT.spells["Death and Decay"]] = {43265, 10},
+         [DKROT.spells["Defile"]] = {152280, 10},
+         [DKROT.spells["Necrotic Plague"]] = {152281, 30},
+         [DKROT.spells["Chilblains"]] = {50435, 10},
       }
       if debugg then print("DKROT:Spells Loaded")end
    end
 
-   local Cooldowns
    function DKROT:LoadCooldowns()
-      if Cooldowns~= nil then wipe(Cooldowns) end
-      Cooldowns = {}
-      Cooldowns = {
+      if DKROT.Cooldowns~= nil then wipe(DKROT.Cooldowns) end
+      DKROT.Cooldowns = {}
+      DKROT.Cooldowns = {
          NormCDs = {--CDs that all DKs get
-            spells["Anti-Magic Shell"],
-            spells["Army of the Dead"],
-            spells["Blood Charge"],
-            spells["Chilblains"],
-            spells["Dark Simulacrum"],
-            spells["Death and Decay"],
-            spells["Death Grip"],
-            spells["Empower Rune Weapon"],
-            spells["Horn of Winter"],
-            spells["Icebound Fortitude"],
-            spells["Mind Freeze"],
-            spells["Outbreak"],
-            spells["Raise Ally"],
-            spells["Raise Dead"],
-            spells["Strangulate"],
-            spells["Unholy Blight"],
-            spells["Unholy Strength"],
+            DKROT.spells["Anti-Magic Shell"],
+            DKROT.spells["Army of the Dead"],
+            DKROT.spells["Blood Charge"],
+            DKROT.spells["Chilblains"],
+            DKROT.spells["Dark Simulacrum"],
+            DKROT.spells["Death and Decay"],
+            DKROT.spells["Death Grip"],
+            DKROT.spells["Empower Rune Weapon"],
+            DKROT.spells["Horn of Winter"],
+            DKROT.spells["Icebound Fortitude"],
+            DKROT.spells["Mind Freeze"],
+            DKROT.spells["Outbreak"],
+            DKROT.spells["Raise Ally"],
+            DKROT.spells["Raise Dead"],
+            DKROT.spells["Strangulate"],
+            DKROT.spells["Unholy Blight"],
+            DKROT.spells["Unholy Strength"],
          },
          TalentCDs ={
-            spells["Anti-Magic Zone"],
-            spells["Asphyxiate"],
-            spells["Conversion"],
-            spells["Death's Advance"],
-            spells["Death Pact"],
-            spells["Desecrated Ground"],
-            spells["Gorefiend's Grasp"],
-            spells["Lichborne"],
-            spells["Plague Leech"],
-            spells["Remorseless Winter"],
-            spells["Runic Corruption"],
+            DKROT.spells["Anti-Magic Zone"],
+            DKROT.spells["Asphyxiate"],
+            DKROT.spells["Conversion"],
+            DKROT.spells["Death's Advance"],
+            DKROT.spells["Death Pact"],
+            DKROT.spells["Desecrated Ground"],
+            DKROT.spells["Gorefiend's Grasp"],
+            DKROT.spells["Lichborne"],
+            DKROT.spells["Plague Leech"],
+            DKROT.spells["Remorseless Winter"],
+            DKROT.spells["Runic Corruption"],
          },
          BloodCDs = {
-            spells["Blood Shield"],
-            spells["Bone Shield"],
-            spells["Crimson Scourge"],
-            spells["Dancing Rune Weapon"],
-            spells["Dark Command"],
-            spells["Rune Tap"],
-            spells["Scent of Blood"],
-            spells["Vampiric Blood"],
-            spells["Will of the Necropolis"],
+            DKROT.spells["Blood Shield"],
+            DKROT.spells["Bone Shield"],
+            DKROT.spells["Crimson Scourge"],
+            DKROT.spells["Dancing Rune Weapon"],
+            DKROT.spells["Dark Command"],
+            DKROT.spells["Rune Tap"],
+            DKROT.spells["Scent of Blood"],
+            DKROT.spells["Vampiric Blood"],
+            DKROT.spells["Will of the Necropolis"],
          },
          FrostCDs = {
-            spells["Freezing Fog"],
-            spells["Killing Machine"],
-            spells["Pillar of Frost"],
+            DKROT.spells["Freezing Fog"],
+            DKROT.spells["Killing Machine"],
+            DKROT.spells["Pillar of Frost"],
          },
          UnholyCDs = {
-            spells["Dark Transformation"],
-            spells["Gnaw"],
-            spells["Shadow Infusion"],
-            spells["Sudden Doom"],
-            spells["Summon Gargoyle"],
+            DKROT.spells["Dark Transformation"],
+            DKROT.spells["Gnaw"],
+            DKROT.spells["Shadow Infusion"],
+            DKROT.spells["Sudden Doom"],
+            DKROT.spells["Summon Gargoyle"],
          },
          Buffs = {--List of Buffs {Who gets buff?, Is it also a CD?}
             --normal
-            [spells["Anti-Magic Shell"]] = {"player", true},
-            [spells["Asphyxiate"]] = {"target", true},
-            [spells["Blood Charge"]] = {"player", false},
-            [spells["Chilblains"]] = {"target", false},
-            [spells["Conversion"]] = {"player", false},
-            [spells["Dark Simulacrum"]] = {"target", true},
-            [spells["Death's Advance"]] = {"player", true},
-            [spells["Horn of Winter"]] = {"player", true},
-            [spells["Icebound Fortitude"]] = {"player", true},
-            [spells["Lichborne"]] = {"player", true},
-            [spells["Remorseless Winter"]] = {"player", true},
-            [spells["Remorseless Winter"]] = {"target", true},
-            [spells["Runic Corruption"]] = {"player", false},
-            [spells["Soul Reaper"]] = {"target", false},
-            [spells["Strangulate"]] = {"target", true},
-            [spells["Unholy Blight"]] = {"player", true},
-            [spells["Unholy Strength"]] = {"player", false},
+            [DKROT.spells["Anti-Magic Shell"]] = {"player", true},
+            [DKROT.spells["Asphyxiate"]] = {"target", true},
+            [DKROT.spells["Blood Charge"]] = {"player", false},
+            [DKROT.spells["Chilblains"]] = {"target", false},
+            [DKROT.spells["Conversion"]] = {"player", false},
+            [DKROT.spells["Dark Simulacrum"]] = {"target", true},
+            [DKROT.spells["Death's Advance"]] = {"player", true},
+            [DKROT.spells["Horn of Winter"]] = {"player", true},
+            [DKROT.spells["Icebound Fortitude"]] = {"player", true},
+            [DKROT.spells["Lichborne"]] = {"player", true},
+            [DKROT.spells["Remorseless Winter"]] = {"player", true},
+            [DKROT.spells["Remorseless Winter"]] = {"target", true},
+            [DKROT.spells["Runic Corruption"]] = {"player", false},
+            [DKROT.spells["Soul Reaper"]] = {"target", false},
+            [DKROT.spells["Strangulate"]] = {"target", true},
+            [DKROT.spells["Unholy Blight"]] = {"player", true},
+            [DKROT.spells["Unholy Strength"]] = {"player", false},
 
             --blood
-            [spells["Blood Shield"]] = {"player", false},
-            [spells["Bone Shield"]] = {"player", true},
-            [spells["Crimson Scourge"]] = {"player", false},
-            [spells["Dancing Rune Weapon"]] = {"player", true},
-            [spells["Scent of Blood"]] = {"player", false},
-            [spells["Vampiric Blood"]] = {"player", true},
-            [spells["Will of the Necropolis"]] = {"player", false},
+            [DKROT.spells["Blood Shield"]] = {"player", false},
+            [DKROT.spells["Bone Shield"]] = {"player", true},
+            [DKROT.spells["Crimson Scourge"]] = {"player", false},
+            [DKROT.spells["Dancing Rune Weapon"]] = {"player", true},
+            [DKROT.spells["Scent of Blood"]] = {"player", false},
+            [DKROT.spells["Vampiric Blood"]] = {"player", true},
+            [DKROT.spells["Will of the Necropolis"]] = {"player", false},
 
             --frost
-            [spells["Pillar of Frost"]] = {"player", true},
-            [spells["Freezing Fog"]] = {"player", false},
-            [spells["Killing Machine"]] = {"player", false},
+            [DKROT.spells["Pillar of Frost"]] = {"player", true},
+            [DKROT.spells["Freezing Fog"]] = {"player", false},
+            [DKROT.spells["Killing Machine"]] = {"player", false},
 
             --unholy
-            [spells["Dark Transformation"]] = {"pet", false},
-            [spells["Shadow Infusion"]] = {"pet", false},
-            [spells["Sudden Doom"]] = {"player", false},
+            [DKROT.spells["Dark Transformation"]] = {"pet", false},
+            [DKROT.spells["Shadow Infusion"]] = {"pet", false},
+            [DKROT.spells["Sudden Doom"]] = {"player", false},
          },
          Moves = {--List of Moves that can be watched when availible
-            spells["Blood Boil"],
-            spells["Death Coil"],
-            spells["Death Siphon"],
-            spells["Death Strike"],
-            spells["Festering Strike"],
-            spells["Frost Strike"],
-            spells["Howling Blast"],
-            spells["Icy Touch"],
-            spells["Obliterate"],
-            spells["Plague Strike"],
-            spells["Scourge Strike"],
-            spells["Soul Reaper"],
+            DKROT.spells["Blood Boil"],
+            DKROT.spells["Death Coil"],
+            DKROT.spells["Death Siphon"],
+            DKROT.spells["Death Strike"],
+            DKROT.spells["Festering Strike"],
+            DKROT.spells["Frost Strike"],
+            DKROT.spells["Howling Blast"],
+            DKROT.spells["Icy Touch"],
+            DKROT.spells["Obliterate"],
+            DKROT.spells["Plague Strike"],
+            DKROT.spells["Scourge Strike"],
+            DKROT.spells["Soul Reaper"],
          },
       }
       if debugg then print("DKROT:Cooldowns Loaded")end
-      return Cooldowns
+      return DKROT.Cooldowns
    end
 
    function DKROT:LoadTrinkets()
@@ -285,204 +279,204 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             loaded = false
             if debugg then print("DKROT:Trinket Not Found - Buff: "..info[1])end
          else
-            Cooldowns.Trinkets[name] = info
+            DKROT.Cooldowns.Trinkets[name] = info
          end
       end
-      Cooldowns.Trinkets = {}
+      DKROT.Cooldowns.Trinkets = {}
 
       --Test trinket that doesn't exist
       --AddTrinket(select(1, GetItemInfo(1)), {"Test Trinket"})
 
       --On-Use
       --Impatience of Youth
-      spells["Thrill of Victory"] = GetSpellInfo(91828)
-      AddTrinket(select(1, GetItemInfo(62469)), {spells["Thrill of Victory"], true, 62469})
+      DKROT.spells["Thrill of Victory"] = GetSpellInfo(91828)
+      AddTrinket(select(1, GetItemInfo(62469)), {DKROT.spells["Thrill of Victory"], true, 62469})
 
       --Vial of Stolen Memories
-      spells["Memory of Invincibility"] = GetSpellInfo(92213)
-      AddTrinket(select(1, GetItemInfo(59515)), {spells["Memory of Invincibility"], true, 59515})
+      DKROT.spells["Memory of Invincibility"] = GetSpellInfo(92213)
+      AddTrinket(select(1, GetItemInfo(59515)), {DKROT.spells["Memory of Invincibility"], true, 59515})
 
       --Figurine - King of Boars
-      spells["King of Boars"] = GetSpellInfo(73522)
-      AddTrinket(select(1, GetItemInfo(52351)), {spells["King of Boars"], true, 52351})
+      DKROT.spells["King of Boars"] = GetSpellInfo(73522)
+      AddTrinket(select(1, GetItemInfo(52351)), {DKROT.spells["King of Boars"], true, 52351})
 
       --Figurine - Earthen Guardian
-      spells["Earthen Guardian"] = GetSpellInfo(73550)
-      AddTrinket(select(1, GetItemInfo(52352)), {spells["Earthen Guardian"], true, 52352})
+      DKROT.spells["Earthen Guardian"] = GetSpellInfo(73550)
+      AddTrinket(select(1, GetItemInfo(52352)), {DKROT.spells["Earthen Guardian"], true, 52352})
 
       --Might of the Ocean
-      spells["Typhoon"] = GetSpellInfo(91340)
-      AddTrinket(select(1, GetItemInfo(56285)), {spells["Typhoon"], true, 56285})
+      DKROT.spells["Typhoon"] = GetSpellInfo(91340)
+      AddTrinket(select(1, GetItemInfo(56285)), {DKROT.spells["Typhoon"], true, 56285})
 
       --Magnetite Mirror
-      spells["Polarization"] = GetSpellInfo(91351)
-      AddTrinket(select(1, GetItemInfo(55814)), {spells["Polarization"], true, 55814})
+      DKROT.spells["Polarization"] = GetSpellInfo(91351)
+      AddTrinket(select(1, GetItemInfo(55814)), {DKROT.spells["Polarization"], true, 55814})
 
       --Mirror of Broken Images
-      spells["Image of Immortality"] = GetSpellInfo(92222)
-      AddTrinket(select(1, GetItemInfo(62466)), {spells["Image of Immortality"], true, 62466})
+      DKROT.spells["Image of Immortality"] = GetSpellInfo(92222)
+      AddTrinket(select(1, GetItemInfo(62466)), {DKROT.spells["Image of Immortality"], true, 62466})
 
       --Essence of the Eternal Flame
-      spells["Essence of the Eternal Flame"] = GetSpellInfo(97010)
-      AddTrinket(select(1, GetItemInfo(69002)), {spells["Essence of the Eternal Flame"], true, 69002})
+      DKROT.spells["Essence of the Eternal Flame"] = GetSpellInfo(97010)
+      AddTrinket(select(1, GetItemInfo(69002)), {DKROT.spells["Essence of the Eternal Flame"], true, 69002})
 
       --Moonwell Phial
-      spells["Summon Splashing Waters"] = GetSpellInfo(101492)
-      AddTrinket(select(1, GetItemInfo(70143)), {spells["Summon Splashing Waters"], true, 70143})
+      DKROT.spells["Summon Splashing Waters"] = GetSpellInfo(101492)
+      AddTrinket(select(1, GetItemInfo(70143)), {DKROT.spells["Summon Splashing Waters"], true, 70143})
 
       --Scales of Life
-      spells["Weight of a Feather"] = GetSpellInfo(97117)
-      AddTrinket(select(1, GetItemInfo(69109)), {spells["Weight of a Feather"], true, 69109})
+      DKROT.spells["Weight of a Feather"] = GetSpellInfo(97117)
+      AddTrinket(select(1, GetItemInfo(69109)), {DKROT.spells["Weight of a Feather"], true, 69109})
 
       --Fire of the Deep
-      spells["Elusive"] = GetSpellInfo(109779)
-      AddTrinket(select(1, GetItemInfo(78008)), {spells["Elusive"], true, 78008})
+      DKROT.spells["Elusive"] = GetSpellInfo(109779)
+      AddTrinket(select(1, GetItemInfo(78008)), {DKROT.spells["Elusive"], true, 78008})
 
       --Rotting Skull
-      spells["Titanic Strength"] = GetSpellInfo(109746)
-      AddTrinket(select(1, GetItemInfo(77116)), {spells["Titanic Strength"], true, 77116})
+      DKROT.spells["Titanic Strength"] = GetSpellInfo(109746)
+      AddTrinket(select(1, GetItemInfo(77116)), {DKROT.spells["Titanic Strength"], true, 77116})
 
       --Soul Barrier
-      spells["Soul Barrier"] = GetSpellInfo(138979)
-      AddTrinket(select(1, GetItemInfo(94528)), {spells["Soul Barrier"], true, 94528})
+      DKROT.spells["Soul Barrier"] = GetSpellInfo(138979)
+      AddTrinket(select(1, GetItemInfo(94528)), {DKROT.spells["Soul Barrier"], true, 94528})
 
       --Badge of Victory
-      spells["Call of Victory"] = GetSpellInfo(92224)
-      AddTrinket(select(1, GetItemInfo(64689)), {spells["Call of Victory"], true, 64689})--Bloodthirsty Gladiator's
-      AddTrinket(select(1, GetItemInfo(61034)), {spells["Call of Victory"], true, 61034})--Vicious Gladiator's s9
-      AddTrinket(select(1, GetItemInfo(70519)), {spells["Call of Victory"], true, 70519})--Vicious Gladiator's s10
-      AddTrinket(select(1, GetItemInfo(70400)), {spells["Call of Victory"], true, 70400})--Ruthless Gladiator's s10
-      AddTrinket(select(1, GetItemInfo(72450)), {spells["Call of Victory"], true, 72450})--Ruthless Gladiator's s11
-      AddTrinket(select(1, GetItemInfo(73496)), {spells["Call of Victory"], true, 73496})--Cataclysmic Gladiator's s11
-      AddTrinket(select(1, GetItemInfo(91410)), {spells["Call of Victory"], true, 126679})--Tyrannical Gladiator's s13
-      AddTrinket(select(1, GetItemInfo(94349)), {spells["Call of Victory"], true, 126679})--Tyrannical Gladiator's s13
+      DKROT.spells["Call of Victory"] = GetSpellInfo(92224)
+      AddTrinket(select(1, GetItemInfo(64689)), {DKROT.spells["Call of Victory"], true, 64689})--Bloodthirsty Gladiator's
+      AddTrinket(select(1, GetItemInfo(61034)), {DKROT.spells["Call of Victory"], true, 61034})--Vicious Gladiator's s9
+      AddTrinket(select(1, GetItemInfo(70519)), {DKROT.spells["Call of Victory"], true, 70519})--Vicious Gladiator's s10
+      AddTrinket(select(1, GetItemInfo(70400)), {DKROT.spells["Call of Victory"], true, 70400})--Ruthless Gladiator's s10
+      AddTrinket(select(1, GetItemInfo(72450)), {DKROT.spells["Call of Victory"], true, 72450})--Ruthless Gladiator's s11
+      AddTrinket(select(1, GetItemInfo(73496)), {DKROT.spells["Call of Victory"], true, 73496})--Cataclysmic Gladiator's s11
+      AddTrinket(select(1, GetItemInfo(91410)), {DKROT.spells["Call of Victory"], true, 126679})--Tyrannical Gladiator's s13
+      AddTrinket(select(1, GetItemInfo(94349)), {DKROT.spells["Call of Victory"], true, 126679})--Tyrannical Gladiator's s13
 
       --PvP Trinkets
-      spells["PvP Trinket"] = GetSpellInfo(42292)
-      AddTrinket(select(1, GetItemInfo(64794)), {spells["PvP Trinket"], true, 64794})--Bloodthirsty
-      AddTrinket(select(1, GetItemInfo(60807)), {spells["PvP Trinket"], true, 60807})--Vicious s9
-      AddTrinket(select(1, GetItemInfo(70607)), {spells["PvP Trinket"], true, 70607})--Vicious s10
-      AddTrinket(select(1, GetItemInfo(70395)), {spells["PvP Trinket"], true, 70395})--Ruthless s10
-      AddTrinket(select(1, GetItemInfo(72413)), {spells["PvP Trinket"], true, 72413})--Ruthless s11
-      AddTrinket(select(1, GetItemInfo(73537)), {spells["PvP Trinket"], true, 73537})--Cataclysmic s11
+      DKROT.spells["PvP Trinket"] = GetSpellInfo(42292)
+      AddTrinket(select(1, GetItemInfo(64794)), {DKROT.spells["PvP Trinket"], true, 64794})--Bloodthirsty
+      AddTrinket(select(1, GetItemInfo(60807)), {DKROT.spells["PvP Trinket"], true, 60807})--Vicious s9
+      AddTrinket(select(1, GetItemInfo(70607)), {DKROT.spells["PvP Trinket"], true, 70607})--Vicious s10
+      AddTrinket(select(1, GetItemInfo(70395)), {DKROT.spells["PvP Trinket"], true, 70395})--Ruthless s10
+      AddTrinket(select(1, GetItemInfo(72413)), {DKROT.spells["PvP Trinket"], true, 72413})--Ruthless s11
+      AddTrinket(select(1, GetItemInfo(73537)), {DKROT.spells["PvP Trinket"], true, 73537})--Cataclysmic s11
 
-      AddTrinket(select(1, GetItemInfo(91329)), {spells["PvP Trinket"], true, 91329})--Tyrannical s13
-      AddTrinket(select(1, GetItemInfo(91330)), {spells["PvP Trinket"], true, 91330})
-      AddTrinket(select(1, GetItemInfo(91331)), {spells["PvP Trinket"], true, 91331})
-      AddTrinket(select(1, GetItemInfo(91332)), {spells["PvP Trinket"], true, 91332})
+      AddTrinket(select(1, GetItemInfo(91329)), {DKROT.spells["PvP Trinket"], true, 91329})--Tyrannical s13
+      AddTrinket(select(1, GetItemInfo(91330)), {DKROT.spells["PvP Trinket"], true, 91330})
+      AddTrinket(select(1, GetItemInfo(91331)), {DKROT.spells["PvP Trinket"], true, 91331})
+      AddTrinket(select(1, GetItemInfo(91332)), {DKROT.spells["PvP Trinket"], true, 91332})
 
-      AddTrinket(select(1, GetItemInfo(91683)), {spells["PvP Trinket"], true, 91683})--Malev s13
+      AddTrinket(select(1, GetItemInfo(91683)), {DKROT.spells["PvP Trinket"], true, 91683})--Malev s13
 
-      AddTrinket(select(1, GetItemInfo(51378)), {spells["PvP Trinket"], true, 51378})
-      AddTrinket(select(1, GetItemInfo(51377)), {spells["PvP Trinket"], true, 51377})
+      AddTrinket(select(1, GetItemInfo(51378)), {DKROT.spells["PvP Trinket"], true, 51378})
+      AddTrinket(select(1, GetItemInfo(51377)), {DKROT.spells["PvP Trinket"], true, 51377})
 
       --Stacking Buff
       --License to Slay
-      spells["Slayer"] = GetSpellInfo(91810)
-      AddTrinket(select(1, GetItemInfo(58180)), {spells["Slayer"], false, 0, 0, false})
+      DKROT.spells["Slayer"] = GetSpellInfo(91810)
+      AddTrinket(select(1, GetItemInfo(58180)), {DKROT.spells["Slayer"], false, 0, 0, false})
 
       --Fury of Angerforge
-      spells["Forged Fury"] = GetSpellInfo(91836)
-      spells["Raw Fury"] = GetSpellInfo(91832)
-      AddTrinket(select(1, GetItemInfo(59461)), {spells["Forged Fury"], false, 120, 0, false, spells["Raw Fury"]})
+      DKROT.spells["Forged Fury"] = GetSpellInfo(91836)
+      DKROT.spells["Raw Fury"] = GetSpellInfo(91832)
+      AddTrinket(select(1, GetItemInfo(59461)), {DKROT.spells["Forged Fury"], false, 120, 0, false, DKROT.spells["Raw Fury"]})
 
       --Apparatus of Khaz'goroth
-      spells["Titanic Power"] = GetSpellInfo(96923)
-      spells["Blessing of Khaz'goroth"] = GetSpellInfo(97127)
-      AddTrinket(select(1, GetItemInfo(69113)), {spells["Blessing of Khaz'goroth"], false, 120, 0, false, spells["Titanic Power"]})
+      DKROT.spells["Titanic Power"] = GetSpellInfo(96923)
+      DKROT.spells["Blessing of Khaz'goroth"] = GetSpellInfo(97127)
+      AddTrinket(select(1, GetItemInfo(69113)), {DKROT.spells["Blessing of Khaz'goroth"], false, 120, 0, false, DKROT.spells["Titanic Power"]})
 
       --Vessel of Acceleration
-      spells["Accelerated"] = GetSpellInfo(96980)
-      AddTrinket(select(1, GetItemInfo(68995)), {spells["Accelerated"], false, 0, 0, false})
+      DKROT.spells["Accelerated"] = GetSpellInfo(96980)
+      AddTrinket(select(1, GetItemInfo(68995)), {DKROT.spells["Accelerated"], false, 0, 0, false})
 
       --Eye of Unmaking
-      spells["Titanic Strength"] = GetSpellInfo(107966)
-      AddTrinket(select(1, GetItemInfo(77200)), {spells["Titanic Strength"], false, 0, 0, false})
+      DKROT.spells["Titanic Strength"] = GetSpellInfo(107966)
+      AddTrinket(select(1, GetItemInfo(77200)), {DKROT.spells["Titanic Strength"], false, 0, 0, false})
 
       --Resolve of Undying
-      spells["Preternatural Evasion"] = GetSpellInfo(109782)
-      AddTrinket(select(1, GetItemInfo(77998)), {spells["Preternatural Evasion"], false, 0, 0, false})
+      DKROT.spells["Preternatural Evasion"] = GetSpellInfo(109782)
+      AddTrinket(select(1, GetItemInfo(77998)), {DKROT.spells["Preternatural Evasion"], false, 0, 0, false})
 
       --Spark of Zandalar
-      spells["Spark of Zandalar"] = GetSpellInfo(138958)
-      AddTrinket(select(1, GetItemInfo(94526)), {spells["Spark of Zandalar"], false, 0, 0, false})
+      DKROT.spells["Spark of Zandalar"] = GetSpellInfo(138958)
+      AddTrinket(select(1, GetItemInfo(94526)), {DKROT.spells["Spark of Zandalar"], false, 0, 0, false})
 
       --Gaze of the Twins
-      spells["Eye of Brutality"] = GetSpellInfo(139170)
-      AddTrinket(select(1, GetItemInfo(94529)), {spells["Eye of Brutality"], false, 0, 0, false})
+      DKROT.spells["Eye of Brutality"] = GetSpellInfo(139170)
+      AddTrinket(select(1, GetItemInfo(94529)), {DKROT.spells["Eye of Brutality"], false, 0, 0, false})
 
       --ICD
       --Heart of Rage
-      spells["Rageheart"] = GetSpellInfo(92345)
-      AddTrinket(select(1, GetItemInfo(65072)), {spells["Rageheart"], false, 20*5, 0, false})
+      DKROT.spells["Rageheart"] = GetSpellInfo(92345)
+      AddTrinket(select(1, GetItemInfo(65072)), {DKROT.spells["Rageheart"], false, 20*5, 0, false})
 
       --Heart of Solace
-      spells["Heartened"] = GetSpellInfo(91363)
-      AddTrinket(select(1, GetItemInfo(55868)), {spells["Heartened"], false, 20*5, 0, false})
+      DKROT.spells["Heartened"] = GetSpellInfo(91363)
+      AddTrinket(select(1, GetItemInfo(55868)), {DKROT.spells["Heartened"], false, 20*5, 0, false})
 
       --Crushing Weight
-      spells["Race Against Death"] = GetSpellInfo(92342)
-      AddTrinket(select(1, GetItemInfo(59506)), {spells["Race Against Death"], false, 15*5, 0, false})
+      DKROT.spells["Race Against Death"] = GetSpellInfo(92342)
+      AddTrinket(select(1, GetItemInfo(59506)), {DKROT.spells["Race Against Death"], false, 15*5, 0, false})
 
       --Symbiotic Worm
-      spells["Turn of the Worm"] = GetSpellInfo(92235)
-      AddTrinket(select(1, GetItemInfo(59332)), {spells["Turn of the Worm"], false, 30, 0, false})
+      DKROT.spells["Turn of the Worm"] = GetSpellInfo(92235)
+      AddTrinket(select(1, GetItemInfo(59332)), {DKROT.spells["Turn of the Worm"], false, 30, 0, false})
 
       --Bedrock Talisman
-      spells["Tectonic Shift"] = GetSpellInfo(92233)
-      AddTrinket(select(1, GetItemInfo(58182)), {spells["Tectonic Shift"], false, 30, 0, false})
+      DKROT.spells["Tectonic Shift"] = GetSpellInfo(92233)
+      AddTrinket(select(1, GetItemInfo(58182)), {DKROT.spells["Tectonic Shift"], false, 30, 0, false})
 
       --Porcelain Crab
-      spells["Hardened Shell"] = GetSpellInfo(92174)
-      AddTrinket(select(1, GetItemInfo(56280)), {spells["Hardened Shell"], false, 20*5, 0, false})
+      DKROT.spells["Hardened Shell"] = GetSpellInfo(92174)
+      AddTrinket(select(1, GetItemInfo(56280)), {DKROT.spells["Hardened Shell"], false, 20*5, 0, false})
 
       --Right Eye of Rajh
-      spells["Eye of Doom"] = GetSpellInfo(91368)
-      AddTrinket(select(1, GetItemInfo(56431)), {spells["Eye of Doom"], false, 10*5, 0, false})
+      DKROT.spells["Eye of Doom"] = GetSpellInfo(91368)
+      AddTrinket(select(1, GetItemInfo(56431)), {DKROT.spells["Eye of Doom"], false, 10*5, 0, false})
 
       --Rosary of Light
-      spells["Rosary of Light"] = GetSpellInfo(102660)
-      AddTrinket(select(1, GetItemInfo(72901)), {spells["Rosary of Light"], false, 20*5, 0, false})
+      DKROT.spells["Rosary of Light"] = GetSpellInfo(102660)
+      AddTrinket(select(1, GetItemInfo(72901)), {DKROT.spells["Rosary of Light"], false, 20*5, 0, false})
 
       --Creche of the Final Dragon
-      spells["Find Weakness"] = GetSpellInfo(109744)
-      AddTrinket(select(1, GetItemInfo(77992)), {spells["Find Weakness"], false, 20*5, 0, false})
+      DKROT.spells["Find Weakness"] = GetSpellInfo(109744)
+      AddTrinket(select(1, GetItemInfo(77992)), {DKROT.spells["Find Weakness"], false, 20*5, 0, false})
 
       --Indomitable Pride
-      spells["Indomitable"] = GetSpellInfo(109786)
-      AddTrinket(select(1, GetItemInfo(78003)), {spells["Indomitable"], false, 60, 0, false})
+      DKROT.spells["Indomitable"] = GetSpellInfo(109786)
+      AddTrinket(select(1, GetItemInfo(78003)), {DKROT.spells["Indomitable"], false, 60, 0, false})
 
       --Soulshifter Vortex
-      spells["Haste"] = GetSpellInfo(109777)
-      AddTrinket(select(1, GetItemInfo(77990)), {spells["Haste"], false, 20*5, 0, false})
+      DKROT.spells["Haste"] = GetSpellInfo(109777)
+      AddTrinket(select(1, GetItemInfo(77990)), {DKROT.spells["Haste"], false, 20*5, 0, false})
 
       --Veil of Lies
-      spells["Veil of Lies"] = GetSpellInfo(102666)
-      AddTrinket(select(1, GetItemInfo(72900)), {spells["Veil of Lies"], false, 20*5, 0, false})
+      DKROT.spells["Veil of Lies"] = GetSpellInfo(102666)
+      AddTrinket(select(1, GetItemInfo(72900)), {DKROT.spells["Veil of Lies"], false, 20*5, 0, false})
 
       --Spidersilk Spindle
-      spells["Loom of Fate"] = GetSpellInfo(97130)
-      AddTrinket(select(1, GetItemInfo(69138)), {spells["Loom of Fate"], false, 60, 0, false})
+      DKROT.spells["Loom of Fate"] = GetSpellInfo(97130)
+      AddTrinket(select(1, GetItemInfo(69138)), {DKROT.spells["Loom of Fate"], false, 60, 0, false})
 
       --Master Pit Fighter
-      spells["Master Pit Fighter"] = GetSpellInfo(109996)
-      AddTrinket(select(1, GetItemInfo(74035)), {spells["Master Pit Fighter"], false, 20*5, 0, false})
+      DKROT.spells["Master Pit Fighter"] = GetSpellInfo(109996)
+      AddTrinket(select(1, GetItemInfo(74035)), {DKROT.spells["Master Pit Fighter"], false, 20*5, 0, false})
 
        --Varo'then's Brooch
-       spells["Varo'then's Brooch"] = GetSpellInfo(102664)
-       AddTrinket(select(1, GetItemInfo(72899)), {spells["Varo'then's Brooch"], false, 20*5, 0, false})
+       DKROT.spells["Varo'then's Brooch"] = GetSpellInfo(102664)
+       AddTrinket(select(1, GetItemInfo(72899)), {DKROT.spells["Varo'then's Brooch"], false, 20*5, 0, false})
 
       --Luckydo Coin
-      spells["Luckydo Coin"] = GetSpellInfo(120175)
-      AddTrinket(select(1, GetItemInfo(82578)), {spells["Luckydo Coin"], false, 20*5, 0, false})
+      DKROT.spells["Luckydo Coin"] = GetSpellInfo(120175)
+      AddTrinket(select(1, GetItemInfo(82578)), {DKROT.spells["Luckydo Coin"], false, 20*5, 0, false})
 
       --Brutal Talisman of the Shado-Pan Assault
-      spells["Surge of Strength"] = GetSpellInfo(138702)
-      AddTrinket(select(1, GetItemInfo(94508)), {spells["Surge of Strength"], false, 20*5, 0, false})
+      DKROT.spells["Surge of Strength"] = GetSpellInfo(138702)
+      AddTrinket(select(1, GetItemInfo(94508)), {DKROT.spells["Surge of Strength"], false, 20*5, 0, false})
 
       --Fabled Feather of Ji-Kun
-      spells["Feathers of Fury"] = GetSpellInfo(138759)
-      AddTrinket(select(1, GetItemInfo(94515)), {spells["Feathers of Fury"], false, 20*5, 0, false})
+      DKROT.spells["Feathers of Fury"] = GetSpellInfo(138759)
+      AddTrinket(select(1, GetItemInfo(94515)), {DKROT.spells["Feathers of Fury"], false, 20*5, 0, false})
 
       if debugg then print("DKROT:Trinkets Loaded")end
       return loaded
@@ -503,7 +497,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
 
    --In: start- when the spell cd started  dur- duration of the cd
    --Out: returns if the spell is or will be off cd in the next GCD
-   local function isOffCD(spell)
+   function DKROT:isOffCD(spell)
       local start, dur = GetSpellCooldown(spell)
       return (dur + start - curtime - GCD <= 0)
    end
@@ -602,9 +596,9 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    function DKROT:CreateCDs()
       DKROT.CD = {}
 
-      --Create two frames in which 2 icons will placed in each
+      -- Create two frames in which 2 icons will placed in each
       for i = 1, 4 do
-         DKROT.CD[i] = CreateFrame("Button", "DKROT.CD"..i, DKROT)
+         DKROT.CD[i] = CreateFrame("Button", "DKROT.CD"..i, DKROT.MainFrame)
          DKROT.CD[i]:SetWidth(34)
          DKROT.CD[i]:SetHeight(68)
          DKROT.CD[i]:SetFrameStrata("BACKGROUND")
@@ -627,7 +621,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
 
       --Create the Icons with desired paramaters
       for i = 1, #CDDisplayList do
-         DKROT.CD[CDDisplayList[i]] = DKROT:CreateIcon(CDDisplayList[i].."Butt", DKROT, spells["Army of the Dead"], 32)
+         DKROT.CD[CDDisplayList[i]] = DKROT:CreateIcon(CDDisplayList[i].."Butt", DKROT.MainFrame, DKROT.spells["Army of the Dead"], 32)
          DKROT.CD[CDDisplayList[i]].Time:SetFont(font, 11, "OUTLINE")
          DKROT.CD[CDDisplayList[i]]:SetParent(DKROT.CD[ceil(i/2)])
          DKROT.CD[CDDisplayList[i]]:EnableMouse(false)
@@ -646,10 +640,10 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    end
 
    function DKROT:CreateUI()
-      DKROT:SetupMoveFunction(DKROT)
+      DKROT:SetupMoveFunction(DKROT.MainFrame)
 
       --Create Rune bar frame
-      DKROT.RuneBar = CreateFrame("Button", "DKROT.RuneBar", DKROT)
+      DKROT.RuneBar = CreateFrame("Button", "DKROT.RuneBar", DKROT.MainFrame)
       DKROT.RuneBar:SetHeight(23)
       DKROT.RuneBar:SetWidth(94)
       DKROT.RuneBar:SetBackdrop{bgFile = 'Interface\\Tooltips\\UI-Tooltip-Background', tile = false, insets = {left = 0, right = 0, top = 0, bottom = 0},}
@@ -683,7 +677,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          frame.Spark.c.lock = false
          return frame
       end
-      DKROT.RuneBarHolder = CreateFrame("Button", "DKROT.RuneBarHolder", DKROT)
+      DKROT.RuneBarHolder = CreateFrame("Button", "DKROT.RuneBarHolder", DKROT.MainFrame)
       DKROT.RuneBarHolder:SetHeight(100)
       DKROT.RuneBarHolder:SetWidth(110)
       DKROT.RuneBarHolder:SetFrameStrata("BACKGROUND")
@@ -699,7 +693,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       DKROT:SetupMoveFunction(DKROT.RuneBarHolder)
 
       --Create Runic Power frame
-      DKROT.RunicPower = CreateFrame("Button", "DKROT.RunicPower", DKROT)
+      DKROT.RunicPower = CreateFrame("Button", "DKROT.RunicPower", DKROT.MainFrame)
       DKROT.RunicPower:SetHeight(23)
       DKROT.RunicPower:SetWidth(47)
       DKROT.RunicPower:SetBackdrop{bgFile = 'Interface\\Tooltips\\UI-Tooltip-Background', tile = false, insets = {left = 0, right = 0, top = 0, bottom = 0},}
@@ -711,30 +705,30 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       DKROT:SetupMoveFunction(DKROT.RunicPower)
 
       --Create frame for Diseases with 2 icons for their respective disease
-      DKROT.Diseases = CreateFrame("Button", "DKROT.Diseases", DKROT)
+      DKROT.Diseases = CreateFrame("Button", "DKROT.Diseases", DKROT.MainFrame)
       DKROT.Diseases:SetHeight(24)
       DKROT.Diseases:SetWidth(47)
       DKROT.Diseases:SetFrameStrata("BACKGROUND")
       DKROT.Diseases:SetBackdrop{bgFile = 'Interface\\Tooltips\\UI-Tooltip-Background', tile = false, insets = {left = 0, right = 0, top = 0, bottom = 0},}
       DKROT.Diseases:SetBackdropColor(0, 0, 0, 0.5)
-      DKROT.Diseases.BP = DKROT:CreateIcon("DKROT.Diseases.BP", DKROT.Diseases, spells["Blood Plague"], 21)
+      DKROT.Diseases.BP = DKROT:CreateIcon("DKROT.Diseases.BP", DKROT.Diseases, DKROT.spells["Blood Plague"], 21)
       DKROT.Diseases.BP:SetParent(DKROT.Diseases)
       DKROT.Diseases.BP:SetPoint("TOPRIGHT", DKROT.Diseases, "TOPRIGHT", -1, -1)
       DKROT.Diseases.BP:SetBackdropColor(0, 0, 0, 0)
-      DKROT.Diseases.FF = DKROT:CreateIcon("DKROT.Diseases.FF", DKROT.Diseases, spells["Frost Fever"], 21)
+      DKROT.Diseases.FF = DKROT:CreateIcon("DKROT.Diseases.FF", DKROT.Diseases, DKROT.spells["Frost Fever"], 21)
       DKROT.Diseases.FF:SetParent(DKROT.Diseases)
       DKROT.Diseases.FF:SetPoint("RIGHT", DKROT.Diseases.BP, "LEFT", -3, 0)
       DKROT.Diseases.FF:SetBackdropColor(0, 0, 0, 0)
       DKROT:SetupMoveFunction(DKROT.Diseases)
 
       --Create the Frame and Icon for the large main Priority Icon
-      DKROT.Move = DKROT:CreateIcon('DKROT.Move', DKROT, spells["Death Coil"], 47)
+      DKROT.Move = DKROT:CreateIcon('DKROT.Move', DKROT.MainFrame, DKROT.spells["Death Coil"], 47)
       DKROT.Move.Time:SetFont(font, 16, "OUTLINE")
       DKROT.Move.Stack:SetFont(font, 15, "OUTLINE")
       DKROT:SetupMoveFunction(DKROT.Move)
 
       --Create backdrop for move
-      DKROT.MoveBackdrop = CreateFrame('Frame', nil, DKROT)
+      DKROT.MoveBackdrop = CreateFrame('Frame', nil, DKROT.MainFrame)
       DKROT.MoveBackdrop:SetHeight(47)
       DKROT.MoveBackdrop:SetWidth(47)
       DKROT.MoveBackdrop:SetFrameStrata("BACKGROUND")
@@ -743,11 +737,11 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       DKROT.MoveBackdrop:SetAllPoints(DKROT.Move)
 
       --Mini AOE icon to be placed in the Priority Icon
-      DKROT.Move.AOE = DKROT:CreateIcon('DKROT.AOE', DKROT.Move, spells["Death Coil"], 18)
+      DKROT.Move.AOE = DKROT:CreateIcon('DKROT.AOE', DKROT.Move, DKROT.spells["Death Coil"], 18)
       DKROT.Move.AOE:SetPoint("BOTTOMLEFT", DKROT.Move, "BOTTOMLEFT", 2, 2)
 
       --Mini Interrupt icon to be placed in the Priority Icon
-      DKROT.Move.Interrupt = DKROT:CreateIcon('DKROT.Interrupt', DKROT.Move, spells["Mind Freeze"], 18)
+      DKROT.Move.Interrupt = DKROT:CreateIcon('DKROT.Interrupt', DKROT.Move, DKROT.spells["Mind Freeze"], 18)
       DKROT.Move.Interrupt:SetPoint("TOPRIGHT", DKROT.Move, "TOPRIGHT", -2, -2)
       if debugg then print("DKROT:UI Created")end
 
@@ -777,11 +771,11 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       frame.Stack:SetText("")
 
       --If the option is not set to nothing
-      if DKROT_Settings.CD[Current_Spec][location] ~= nil and DKROT_Settings.CD[Current_Spec][location][1] ~= nil and
-         DKROT_Settings.CD[Current_Spec][location][1] ~= DKROT_OPTIONS_FRAME_VIEW_NONE then
+      if DKROT_Settings.CD[DKROT.Current_Spec][location] ~= nil and DKROT_Settings.CD[DKROT.Current_Spec][location][1] ~= nil and
+         DKROT_Settings.CD[DKROT.Current_Spec][location][1] ~= DKROT_OPTIONS_FRAME_VIEW_NONE then
          frame:SetAlpha(1)
          frame.Icon:SetVertexColor(1, 1, 1, 1)
-         if DKROT_Settings.CD[Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_PRIORITY then --Priority
+         if DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_PRIORITY then --Priority
             --If targeting something that you can attack and is not dead
             if (UnitCanAttack("player", "target") and (not UnitIsDead("target"))) then
                --Get Icon from Priority Rotation
@@ -789,15 +783,15 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             else
                frame.Icon:SetTexture(nil)
             end
-         elseif DKROT_Settings.CD[Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_PRESENCE then --Presence
+         elseif DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_PRESENCE then --Presence
             frame.Icon:SetTexture(nil)
             if PLAYER_PRESENCE > 0 then
                frame.Icon:SetTexture(select(1, GetShapeshiftFormInfo(PLAYER_PRESENCE)))
             end
-         elseif DKROT_Settings.CD[Current_Spec][location][IS_BUFF] then --Buff/DeBuff
+         elseif DKROT_Settings.CD[DKROT.Current_Spec][location][IS_BUFF] then --Buff/DeBuff
             local icon, count, dur, expirationTime
 
-            if DKROT_Settings.CD[Current_Spec][location][1] == spells["Dark Simulacrum"] then
+            if DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT.spells["Dark Simulacrum"] then
                local id
                if (curtime - simtime) >= 5 then
                   simtime = curtime
@@ -817,10 +811,10 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             end
 
             --if its on a target then its a debuff, otherwise its a buff
-            if Cooldowns.Buffs[DKROT_Settings.CD[Current_Spec][location][1]][1] == "target" then
-               _, _, icon, count, _, dur, expirationTime = UnitDebuff("target", DKROT_Settings.CD[Current_Spec][location][1])
+            if DKROT.Cooldowns.Buffs[DKROT_Settings.CD[DKROT.Current_Spec][location][1]][1] == "target" then
+               _, _, icon, count, _, dur, expirationTime = UnitDebuff("target", DKROT_Settings.CD[DKROT.Current_Spec][location][1])
             else
-               _, _, icon, count, _, dur, expirationTime = UnitBuff(Cooldowns.Buffs[DKROT_Settings.CD[Current_Spec][location][1]][1], DKROT_Settings.CD[Current_Spec][location][1])
+               _, _, icon, count, _, dur, expirationTime = UnitBuff(DKROT.Cooldowns.Buffs[DKROT_Settings.CD[DKROT.Current_Spec][location][1]][1], DKROT_Settings.CD[DKROT.Current_Spec][location][1])
             end
             frame.Icon:SetTexture(icon)
 
@@ -828,35 +822,35 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             if icon ~= nil and ceil(expirationTime - curtime) > 0 then
                frame.Icon:SetVertexColor(0.5, 0.5, 0.5, 1)
                frame.Time:SetText(formatTime(ceil(expirationTime - curtime)))
-               if DKROT_Settings.CD[Current_Spec][location][1] == spells["Blood Shield"] then count = bsamount end
+               if DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT.spells["Blood Shield"] then count = bsamount end
                if count > 1 then frame.Stack:SetText(count) end
             end
 
 
 
-         elseif inTable(Cooldowns.Moves, DKROT_Settings.CD[Current_Spec][location][1]) then --Move
-            icon = GetSpellTexture(DKROT_Settings.CD[Current_Spec][location][1])
+         elseif inTable(DKROT.Cooldowns.Moves, DKROT_Settings.CD[DKROT.Current_Spec][location][1]) then --Move
+            icon = GetSpellTexture(DKROT_Settings.CD[DKROT.Current_Spec][location][1])
             if icon ~= nil then
                --Check if move is off CD
-               if isOffCD(DKROT_Settings.CD[Current_Spec][location][1]) and IsUsableSpell(DKROT_Settings.CD[Current_Spec][location][1]) then
-                  icon = DKROT:GetRangeandIcon(frame.Icon, DKROT_Settings.CD[Current_Spec][location][1])
+               if DKROT:isOffCD(DKROT_Settings.CD[DKROT.Current_Spec][location][1]) and IsUsableSpell(DKROT_Settings.CD[DKROT.Current_Spec][location][1]) then
+                  icon = DKROT:GetRangeandIcon(frame.Icon, DKROT_Settings.CD[DKROT.Current_Spec][location][1])
                else
                   icon = nil
                end
             end
             frame.Icon:SetTexture(icon)
-         elseif DKROT_Settings.CD[Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1 or
-            DKROT_Settings.CD[Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT2 then --Trinkets
+         elseif DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1 or
+            DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT2 then --Trinkets
 
             local id
-            if DKROT_Settings.CD[Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1 then
+            if DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1 then
                id = GetInventoryItemID("player", 13)
             else
                id = GetInventoryItemID("player", 14)
             end
             local trink
             if id ~= nil then
-               trink = Cooldowns.Trinkets[select(1,GetItemInfo(id))]
+               trink = DKROT.Cooldowns.Trinkets[select(1,GetItemInfo(id))]
             end
 
             if trink ~= nil then
@@ -896,11 +890,11 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             else
                frame.Icon:SetTexture(nil)
             end
-         elseif  DKROT_Settings.CD[Current_Spec][location][1] == DKROT_OPTIONS_CDR_RACIAL then
-            icon = DKROT:GetRangeandIcon(frame.Icon, spells[PLAYER_RACE])
+         elseif  DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_RACIAL then
+            icon = DKROT:GetRangeandIcon(frame.Icon, DKROT.spells[PLAYER_RACE])
             frame.Icon:SetTexture(icon)
             if icon ~= nil then
-               start, dur, active =  GetSpellCooldown(spells[PLAYER_RACE])
+               start, dur, active =  GetSpellCooldown(DKROT.spells[PLAYER_RACE])
                t = ceil(start + dur - curtime)
                if active == 1 and dur > 7 then
                   frame.Icon:SetVertexColor(0.5, 0.5, 0.5, 1)
@@ -910,10 +904,10 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             end
 
          else --Cooldown
-            icon = DKROT:GetRangeandIcon(frame.Icon, DKROT_Settings.CD[Current_Spec][location][1])
+            icon = DKROT:GetRangeandIcon(frame.Icon, DKROT_Settings.CD[DKROT.Current_Spec][location][1])
             frame.Icon:SetTexture(icon)
             if icon ~= nil then
-               start, dur, active =  GetSpellCooldown(DKROT_Settings.CD[Current_Spec][location][1])
+               start, dur, active =  GetSpellCooldown(DKROT_Settings.CD[DKROT.Current_Spec][location][1])
                t = ceil(start + dur - curtime)
                if active == 1 and dur > 7 then
                   frame.Icon:SetVertexColor(0.5, 0.5, 0.5, 1)
@@ -927,7 +921,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             frame:SetAlpha(0)
          end
       else
-         DKROT_Settings.CD[Current_Spec][location][1] = DKROT_OPTIONS_FRAME_VIEW_NONE
+         DKROT_Settings.CD[DKROT.Current_Spec][location][1] = DKROT_OPTIONS_FRAME_VIEW_NONE
          frame:SetAlpha(0)
       end
    end
@@ -955,7 +949,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
 
    --Called to update all the frames positions and scales
    function DKROT:UpdatePosition()
-      DKROT:MoveFrame(DKROT)
+      DKROT:MoveFrame(DKROT.MainFrame)
       DKROT:MoveFrame(DKROT.CD[1])
       DKROT:MoveFrame(DKROT.CD[2])
       DKROT:MoveFrame(DKROT.CD[3])
@@ -977,7 +971,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT.DT:EnableMouse(true)
       end
 
-      DKROT:SetScale(DKROT_Settings.Scale)
+      DKROT.MainFrame:SetScale(DKROT_Settings.Scale)
       if debugg then print("DKROT:UpdatePosition")end
    end
 
@@ -994,9 +988,9 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    --Main function for updating all information
    function DKROT:UpdateUI()
       if (UnitCanAttack("player", "target") and (not UnitIsDead("target"))) then
-         DKROT:SetAlpha(DKROT_Settings.NormTrans)
+         DKROT.MainFrame:SetAlpha(DKROT_Settings.NormTrans)
       else
-         DKROT:SetAlpha(DKROT_Settings.CombatTrans)
+         DKROT.MainFrame:SetAlpha(DKROT_Settings.CombatTrans)
       end
 
       --GCD
@@ -1083,13 +1077,13 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT.Diseases.FF.Time:SetText("")
          DKROT.Diseases.BP.Time:SetText("")
          if UnitCanAttack("player", "target") and (not UnitIsDead("target")) then
-            local expires = select(7,UnitDebuff("TARGET", spells["Frost Fever"], nil, "PLAYER"))
+            local expires = select(7,UnitDebuff("TARGET", DKROT.spells["Frost Fever"], nil, "PLAYER"))
             if  expires ~= nil and (expires - curtime) > 0 then
                DKROT.Diseases.FF.Icon:SetVertexColor(.5, .5, .5, 1)
                DKROT.Diseases.FF.Time:SetText(string.format("|cffffffff%.2d|r", expires - curtime))
             end
 
-            expires = select(7,UnitDebuff("TARGET", spells["Blood Plague"], nil, "PLAYER"))
+            expires = select(7,UnitDebuff("TARGET", DKROT.spells["Blood Plague"], nil, "PLAYER"))
             if expires ~= nil and (expires - curtime) > 0 then
                DKROT.Diseases.BP.Icon:SetVertexColor(.5, .5, .5, 1)
                DKROT.Diseases.BP.Time:SetText(string.format("|cffffffff%.2d|r", expires - curtime))
@@ -1102,18 +1096,18 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       --Priority Icon
       DKROT.Move.AOE:SetAlpha(0)
       DKROT.Move.Interrupt:SetAlpha(0)
-      if DKROT_Settings.CD[Current_Spec]["DKROT_CDRPanel_DD_Priority"][1] ~= DKROT_OPTIONS_FRAME_VIEW_NONE then
+      if DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][1] ~= DKROT_OPTIONS_FRAME_VIEW_NONE then
          DKROT.Move:SetAlpha(1)
          DKROT.MoveBackdrop:SetAlpha(1)
          DKROT:UpdateCD("DKROT_CDRPanel_DD_Priority", DKROT.Move)
 
          --If Priority on Main Icon
-         if DKROT_Settings.CD[Current_Spec]["DKROT_CDRPanel_DD_Priority"][1] == DKROT_OPTIONS_CDR_CD_PRIORITY then
+         if DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][1] == DKROT_OPTIONS_CDR_CD_PRIORITY then
             if DKROT_Settings.MoveAltInterrupt then --Show Interrupt
                local spell, notint = select(1, UnitCastingInfo("target")), select(9, UnitCastingInfo("target"))
                if spell == nil then spell, notint = select(1, UnitChannelInfo("target")), select(8, UnitChannelInfo("target")) end
                if spell ~= nil and not notint then
-                  if isOffCD(spells["Mind Freeze"]) then
+                  if DKROT:isOffCD(DKROT.spells["Mind Freeze"]) then
                      DKROT.Move.Interrupt:SetAlpha(1)
                   end
                end
@@ -1126,7 +1120,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
 
       --CDs
       for i = 1, #CDDisplayList do
-         if DKROT_Settings.CD[Current_Spec][ceil(i/2)] then
+         if DKROT_Settings.CD[DKROT.Current_Spec][ceil(i/2)] then
             DKROT.CD[ceil(i/2)]:SetAlpha(1)
             DKROT:UpdateCD(CDDisplayList[i], DKROT.CD[CDDisplayList[i]])
          else
@@ -1137,7 +1131,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       local temp
       for i = 1, 40 do
          if select(1, UnitBuff("player", i)) ~= nil then
-            if UnitBuff("player", i) == spells["Blood Shield"] then
+            if UnitBuff("player", i) == DKROT.spells["Blood Shield"] then
                BloodShieldTooltip:SetUnitBuff("player", i)
                temp = string.gsub(_G["BloodShieldTooltipTextLeft"..2]:GetText(), "[^%d]", "")
 
@@ -1220,7 +1214,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                info.Frame.Icons[j] = DKROT:CreateIcon("DKROT.DT."..j, info.Frame, j, 20)
                info.Frame.Icons[j].Time:SetFont(font, 11, "OUTLINE")
                info.Frame.Icons[j]:SetPoint("RIGHT", -(count*22)-1, 0)
-               info.Frame.Icons[j].Icon:SetTexture(GetSpellTexture(DTspells[j][1]))
+               info.Frame.Icons[j].Icon:SetTexture(GetSpellTexture(DTDKROT.spells[j][1]))
                count = count + 1
             end
          end
@@ -1238,12 +1232,12 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                   else
                      info.NumDots = info.NumDots - 1
                      info.Frame.Icons[j]:SetAlpha(0)
-                     info.Spells[j] = nil
+                     info.DKROT.spells[j] = nil
                   end
                else
                   info.NumDots = info.NumDots - 1
                   if info.Frame.Icons[j]~= nil then info.Frame.Icons[j]:SetAlpha(0) end
-                  info.Spells[j] = nil
+                  info.DKROT.spells[j] = nil
                end
             end
          else
@@ -1310,13 +1304,13 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
 
                         updatedGUIDs[guid] = true
 
-                        if DKROT.DT.Unit[guid].Spells[name] == nil then
+                        if DKROT.DT.Unit[guid].DKROT.spells[name] == nil then
                            DKROT.DT.Unit[guid].NumDots = DKROT.DT.Unit[guid].NumDots + 1
                         end
-                        if name == spells["Death and Decay"] then
-                           DKROT.DT.Unit[guid].Spells[name] = select(1, GetSpellCooldown(name)) + 10
+                        if name == DKROT.spells["Death and Decay"] then
+                           DKROT.DT.Unit[guid].DKROT.spells[name] = select(1, GetSpellCooldown(name)) + 10
                         else
-                           DKROT.DT.Unit[guid].Spells[name] = expt
+                           DKROT.DT.Unit[guid].DKROT.spells[name] = expt
                         end
 
                         if DKROT_Settings.DT.Threat ~= THREAT_OFF then
@@ -1343,13 +1337,13 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       --Called to update a priority icon with next move
       function DKROT:GetNextMove(icon)
          --Call correct function based on spec
-         if (Current_Spec == SPEC_UNHOLY) then
+         if (DKROT.Current_Spec == DKROT.SPECS.UNHOLY) then
             if DKROT_Settings.MoveAltAOE then DKROT.Move.AOE:SetAlpha(1); DKROT.Move.AOE.Icon:SetTexture(DKROT:UnholyAOEMove(DKROT.Move.AOE.Icon)) end
             return DKROT:UnholyMove(icon)
-         elseif (Current_Spec == SPEC_FROST) then
+         elseif (DKROT.Current_Spec == DKROT.SPECS.FROST) then
             if DKROT_Settings.MoveAltAOE then DKROT.Move.AOE:SetAlpha(1); DKROT.Move.AOE.Icon:SetTexture(DKROT:FrostAOEMove(DKROT.Move.AOE.Icon)) end
             return DKROT:FrostMove(icon)
-         elseif (Current_Spec == SPEC_BLOOD) then
+         elseif (DKROT.Current_Spec == DKROT.SPECS.BLOOD) then
             if DKROT_Settings.MoveAltAOE then DKROT.Move.AOE:SetAlpha(1); DKROT.Move.AOE.Icon:SetTexture(DKROT:BloodAOEMove(DKROT.Move.AOE.Icon)) end
             return DKROT:BloodMove(icon)
          else
@@ -1378,9 +1372,9 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       function DKROT:RuneCDs(r)
          --Get individual rune numbers
          local a, b
-         if r == SPEC_UNHOLY then a, b = 3, 4
-         elseif r == SPEC_FROST then a, b = 5, 6
-         elseif r == SPEC_BLOOD then a, b = 1, 2
+         if r == DKROT.SPECS.UNHOLY then a, b = 3, 4
+         elseif r == DKROT.SPECS.FROST then a, b = 5, 6
+         elseif r == DKROT.SPECS.BLOOD then a, b = 1, 2
          end
 
          --Get CD of first rune
@@ -1444,7 +1438,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       --Returns if move is off cooldown or not
       function DKROT:QuickAOESpellCheck(move)
          if DKROT_Settings.MoveAltAOE and GetSpellTexture(move) ~= nil then
-            if isOffCD(move) then
+            if DKROT:isOffCD(move) then
                return true
             end
          end
@@ -1454,44 +1448,44 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       --Determines if Diseases need to be refreshed or applied
       function DKROT:GetDisease(icon)
          --If settings not to worry about diseases, then break
-         if DKROT_Settings.CD[Current_Spec].DiseaseOption == DISEASE_NONE then return false end
+         if DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption == DISEASE_NONE then return false end
 
          --Get Duration left on diseases
          local FFexpires, BPexpires, NPexpires
-         local expires = select(7,UnitDebuff("TARGET", spells["Frost Fever"], nil, "PLAYER"))
+         local expires = select(7,UnitDebuff("TARGET", DKROT.spells["Frost Fever"], nil, "PLAYER"))
          if  expires ~= nil then   FFexpires = expires - curtime end
-         expires = select(7,UnitDebuff("TARGET", spells["Blood Plague"], nil, "PLAYER"))
+         expires = select(7,UnitDebuff("TARGET", DKROT.spells["Blood Plague"], nil, "PLAYER"))
          if expires ~= nil then BPexpires = expires - curtime end
-         expires = select(7, UnitDebuff("TARGET", spells["Necrotic Plague"], nil, "PLAYER"))
+         expires = select(7, UnitDebuff("TARGET", DKROT.spells["Necrotic Plague"], nil, "PLAYER"))
          if expires ~= nil then NPexpires = expires - curtime end
 
          --Check if Outbreak is off CD, is known and Player wants to use it in rotation
-         local outbreak = DKROT_Settings.CD[Current_Spec].Outbreak and IsSpellKnown(77575) and isOffCD(spells["Outbreak"])
+         local outbreak = DKROT_Settings.CD[DKROT.Current_Spec].Outbreak and IsSpellKnown(77575) and DKROT:isOffCD(DKROT.spells["Outbreak"])
 
          --Check if Unholy Blight is up, is known and Player wants to use it in rotation
-         local unholyblight = DKROT_Settings.CD[Current_Spec].UB and IsSpellKnown(115989) and isOffCD(spells["Unholy Blight"])
+         local unholyblight = DKROT_Settings.CD[DKROT.Current_Spec].UB and IsSpellKnown(115989) and DKROT:isOffCD(DKROT.spells["Unholy Blight"])
 
          --Check if Plague Leech is up, is known and Player wants to use it in rotation
-         local plagueleech = DKROT_Settings.CD[Current_Spec].PL and IsSpellKnown(123693) and isOffCD(spells["Plague Leech"])
+         local plagueleech = DKROT_Settings.CD[DKROT.Current_Spec].PL and IsSpellKnown(123693) and DKROT:isOffCD(DKROT.spells["Plague Leech"])
 
 
          -- Apply Frost Fever
          if (FFexpires == nil or FFexpires < 2) and NPexpires == nil then
             if outbreak then --if can use outbreak, then do it
-               return true, DKROT:GetRangeandIcon(icon, spells["Outbreak"])
+               return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Outbreak"])
             elseif unholyblight then --if can use Unholy Blight, then do it
-               return true, DKROT:GetRangeandIcon(icon, spells["Unholy Blight"])
-            elseif (Current_Spec == SPEC_UNHOLY) and ((DKROT:RuneCDs(SPEC_UNHOLY) <= 0) or DKROT:DeathRunes() >= 1) then --Unholy: Plague Strike
-               return true, DKROT:GetRangeandIcon(icon, spells["Plague Strike"])
-            elseif (Current_Spec == SPEC_FROST) and ((DKROT:RuneCDs(SPEC_FROST) <= 0) or DKROT:DeathRunes() >= 1) then --Frost: Howling Blast
-               return true, DKROT:GetRangeandIcon(icon, spells["Howling Blast"])
-            elseif ((DKROT:RuneCDs(SPEC_FROST) <= 0) or DKROT:DeathRunes() >= 1) then --Other: Icy Touch
-               return true, DKROT:GetRangeandIcon(icon, spells["Icy Touch"])
+               return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Unholy Blight"])
+            elseif (DKROT.Current_Spec == DKROT.SPECS.UNHOLY) and ((DKROT:RuneCDs(DKROT.SPECS.UNHOLY) <= 0) or DKROT:DeathRunes() >= 1) then --Unholy: Plague Strike
+               return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
+            elseif (DKROT.Current_Spec == DKROT.SPECS.FROST) and ((DKROT:RuneCDs(DKROT.SPECS.FROST) <= 0) or DKROT:DeathRunes() >= 1) then --Frost: Howling Blast
+               return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+            elseif ((DKROT:RuneCDs(DKROT.SPECS.FROST) <= 0) or DKROT:DeathRunes() >= 1) then --Other: Icy Touch
+               return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Icy Touch"])
             end
          end
 
          --Apply Blood Plague
-         if (DKROT_Settings.CD[Current_Spec].DiseaseOption ~= DISEASE_ONE or outbreak) then
+         if (DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption ~= DISEASE_ONE or outbreak) then
             if (BPexpires == nil or BPexpires < 3) then
                -- Necrotic plague acts as both frost fever and blood plague
                if NPexpires ~= nil and NPexpires > 3 then
@@ -1499,779 +1493,99 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                end
 
                -- Add Death Grip as first priority until PS is in range
-               if DKROT_Settings.DG and (IsSpellInRange(spells["Plague Strike"], "target")) == 0 and IsUsableSpell(spells["Death Grip"]) then
-                  return true, (DKROT:GetRangeandIcon(icon, spells["Death Grip"]))
+               if DKROT_Settings.DG and (IsSpellInRange(DKROT.spells["Plague Strike"], "target")) == 0 and IsUsableSpell(DKROT.spells["Death Grip"]) then
+                  return true, (DKROT:GetRangeandIcon(icon, DKROT.spells["Death Grip"]))
                end
 
                if plagueleech and (BPexpires ~= nil or NPexpires ~= nil) and DKROT:DepletedRunes() > 0 then
-                  return true, DKROT:GetRangeandIcon(icon, spells["Plague Leech"])
+                  return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Leech"])
 
                elseif outbreak then --if can use outbreak, then do it
-                  return true, DKROT:GetRangeandIcon(icon, spells["Outbreak"])
+                  return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Outbreak"])
 
                elseif unholyblight then --if can use Unholy Blight, then do it
-                  return true, DKROT:GetRangeandIcon(icon, spells["Unholy Blight"])
+                  return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Unholy Blight"])
 
-               elseif ((DKROT:RuneCDs(SPEC_UNHOLY) <= 0) or DKROT:DeathRunes() >= 1) then --if rune availible, then use Plague Strike
-                  return true, DKROT:GetRangeandIcon(icon, spells["Plague Strike"])
+               elseif ((DKROT:RuneCDs(DKROT.SPECS.UNHOLY) <= 0) or DKROT:DeathRunes() >= 1) then --if rune availible, then use Plague Strike
+                  return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
                end
             end
          end
          return false
       end
 
-      --Function to determine rotation for Unholy Spec
-      function DKROT:UnholyMove(icon)
-         if DKROT_Settings.CD[Current_Spec].AltRot then
-            return DKROT:UnholyMoveAlt(icon)
-         end
-
-         --Rune Info
-         local frost, lfrost, fd, lfd = DKROT:RuneCDs(SPEC_FROST)
-         local unholy, lunholy = DKROT:RuneCDs(SPEC_UNHOLY)
-         local blood, lblood, bd, lbd = DKROT:RuneCDs(SPEC_BLOOD)
-         local death = DKROT:DeathRunes()
-         local disease, move = DKROT:GetDisease(icon)
-         local bloodCharges = select(4, UnitBuff("player", spells["Blood Charge"]))
-
-         -- Death Pact
-         if GetSpellTexture(spells["Death Pact"]) ~= nil
-            and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
-         then
-            if isOffCD(spells["Death Pact"]) then
-               return GetSpellTexture(spells["Death Pact"])
-            end
-         end
-
-         -- Soul Reaper
-         if GetSpellTexture(spells["Soul Reaper"]) ~= nil and (death >= 1 or unholy <= 0)
-         then
-            if (
-                  GetSpellTexture(spells["Improved Soul Reaper"]) ~= nil
-                  and UnitHealth("target")/UnitHealthMax("target") < 0.45
-               )
-               or UnitHealth("target")/UnitHealthMax("target") < 0.35
-            then
-               if isOffCD(spells["Soul Reaper"]) then
-                  return DKROT:GetRangeandIcon(icon, spells["Soul Reaper"])
-               end
-            end
-         end
-
-         -- Defile
-         if GetSpellTexture(spells["Defile"]) ~= nil then
-            if isOffCD(spells["Defile"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Defile"])
-            end
-         end
-
-         -- Diseases
-         if disease then return move end
-
-         -- Dark Transformation
-         if GetSpellTexture(spells["Dark Transformation"]) ~= nil
-            and select(4, UnitBuff("PET",spells["Shadow Infusion"])) == 5
-            and (unholy <= 0 or death >= 1)
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Dark Transformation"])
-         end
-
-         -- Blood Tap with >= 11 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 11
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
-         end
-
-         -- Death Coil if ghoul is not transformed or have 5 stacks
-         if DKROT_Settings.CD[Current_Spec].RP
-            and (
-               UnitPower("player") >= 30
-               or select(7, UnitBuff("PLAYER",spells["Sudden Doom"]))~= nil
-            )
-            and select(4, UnitBuff("PET",spells["Shadow Infusion"])) ~= 5
-            and UnitBuff("PET",spells["Dark Transformation"]) == nil
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Death Coil"])
-         end
-
-         --Scourge Strike (UU are up or FF or BB are up as Deathrunes)
-         if lunholy <= 0 or (lfrost <= 0 and (fd or lfd)) or (lblood <= 0 and (bd or lbd)) then
-            if DKROT_Settings.MoveAltDND then
-               --Death and Decay
-               if GetSpellTexture(spells["Death and Decay"]) ~= nil then
-                  if isOffCD(spells["Death and Decay"]) then
-                     DKROT.Move.AOE:SetAlpha(1)
-                     DKROT.Move.AOE.Icon:SetTexture(GetSpellTexture(spells["Death and Decay"]))
-                  end
-               end
-            end
-            if GetSpellTexture(spells["Scourge Strike"]) ~= nil then
-               return DKROT:GetRangeandIcon(icon, spells["Scourge Strike"])
-            else
-               return DKROT:GetRangeandIcon(icon, spells["Plague Strike"])
-            end
-         end
-
-         -- Festering Strike (BB and FF are up)
-         if GetSpellTexture(spells["Festering Strike"]) ~= nil then
-            if lfrost <= 0 and lblood <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Festering Strike"])
-            end
-         else
-            -- Icy Touch
-            if lfrost <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Icy Touch"])
-            end
-         end
-
-         -- Death Coil (Sudden Doom, high RP)
-         if DKROT_Settings.CD[Current_Spec].RP
-         and (UnitPower("player") > 80
-            or select(7, UnitBuff("PLAYER",spells["Sudden Doom"])) ~= nil) then
-            return DKROT:GetRangeandIcon(icon, spells["Death Coil"])
-         end
-
-         -- Scourge Strike
-         if unholy <= 0 or death >= 1 then
-            if DKROT_Settings.MoveAltDND then
-               --Death and Decay
-               if GetSpellTexture(spells["Death and Decay"]) ~= nil then
-                  if isOffCD(spells["Death and Decay"]) then
-                     DKROT.Move.AOE:SetAlpha(1)
-                     DKROT.Move.AOE.Icon:SetTexture(GetSpellTexture(spells["Death and Decay"]))
-                  end
-               end
-            end
-            if GetSpellTexture(spells["Scourge Strike"]) ~= nil then
-               return DKROT:GetRangeandIcon(icon, spells["Scourge Strike"])
-            else
-               return DKROT:GetRangeandIcon(icon, spells["Plague Strike"])
-            end
-         end
-
-         -- Festering Strike
-         if GetSpellTexture(spells["Festering Strike"]) ~= nil then
-            if frost <= 0 and blood <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Festering Strike"])
-            end
-         else
-            --Icy Touch
-            if frost <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Icy Touch"])
-            end
-         end
-
-         --Blood Tap with >= 5 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 5
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
-         end
-
-         --Empower Rune Weapon
-         if GetSpellTexture(spells["Empower Rune Weapon"]) ~= nil and DKROT_Settings.CD[Current_Spec].ERW then
-            if isOffCD(spells["Empower Rune Weapon"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Empower Rune Weapon"])
-            end
-         end
-
-         -- If nothing else can be done
-         return nil
-      end
-
-      --Festerblight, apply diseases one time and then just extend them with festering strike
-      function DKROT:UnholyMoveAlt(icon)
-
-         --Rune Info
-         local frost, lfrost, fd, lfd = DKROT:RuneCDs(SPEC_FROST)
-         local unholy, lunholy = DKROT:RuneCDs(SPEC_UNHOLY)
-         local blood, lblood, bd, lbd = DKROT:RuneCDs(SPEC_BLOOD)
-         local death = DKROT:DeathRunes()
-         local bloodCharges = select(4, UnitBuff("player", spells["Blood Charge"]))
-
-         -- Death Pact
-         if GetSpellTexture(spells["Death Pact"]) ~= nil
-            and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
-         then
-            if isOffCD(spells["Death Pact"]) then
-               return GetSpellTexture(spells["Death Pact"])
-            end
-         end
-
-         -- Soul Reaper
-         if GetSpellTexture(spells["Soul Reaper"]) ~= nil and (death >= 1 or unholy <= 0)
-         then
-            if (
-                  GetSpellTexture(spells["Improved Soul Reaper"]) ~= nil
-                  and UnitHealth("target")/UnitHealthMax("target") < 0.45
-               )
-               or UnitHealth("target")/UnitHealthMax("target") < 0.35
-            then
-               if isOffCD(spells["Soul Reaper"]) then
-                  return DKROT:GetRangeandIcon(icon, spells["Soul Reaper"])
-               end
-            end
-         end
-
-         -- Defile
-         if GetSpellTexture(spells["Defile"]) ~= nil then
-            if isOffCD(spells["Defile"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Defile"])
-            end
-         end
-
-         -- Diseases
-         local disease, move = DKROT:GetDisease(icon)
-         if disease then   return move   end
-
-         -- Dark Transformation
-         if GetSpellTexture(spells["Dark Transformation"]) ~= nil
-         and select(4, UnitBuff("PET",spells["Shadow Infusion"])) == 5
-         and (unholy <= 0 or death >= 1) then
-            return DKROT:GetRangeandIcon(icon, spells["Dark Transformation"])
-         end
-
-         -- Blood Tap with >= 11 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 11
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
-         end
-
-         -- Death Coil if ghoul is not transformed or have 5 stacks
-         if DKROT_Settings.CD[Current_Spec].RP
-            and (
-               UnitPower("player") >= 30
-               or select(7, UnitBuff("PLAYER",spells["Sudden Doom"]))~= nil
-            )
-            and select(4, UnitBuff("PET",spells["Shadow Infusion"])) ~= 5
-            and UnitBuff("PET",spells["Dark Transformation"]) == nil
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Death Coil"])
-         end
-
-         -- Scourge Strike  (UU are up)
-         if (lunholy <= 0) then
-            if DKROT_Settings.MoveAltDND then
-               --Death and Decay
-               if GetSpellTexture(spells["Death and Decay"]) ~= nil then
-                  if isOffCD(spells["Death and Decay"]) then
-                     DKROT.Move.AOE:SetAlpha(1)
-                     DKROT.Move.AOE.Icon:SetTexture(GetSpellTexture(spells["Death and Decay"]))
-                  end
-               end
-            end
-            if GetSpellTexture(spells["Scourge Strike"]) ~= nil then
-               return DKROT:GetRangeandIcon(icon, spells["Scourge Strike"])
-            else return DKROT:GetRangeandIcon(icon, spells["Plague Strike"])
-            end
-         end
-
-         --Festering Strike (BB and FF are up)
-         if GetSpellTexture(spells["Festering Strike"]) ~= nil then
-            if lfrost <= 0 and lblood <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Festering Strike"])
-            end
-         else
-            --Icy Touch
-            if lfrost <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Icy Touch"])
-            end
-         end
-
-         --Death Coil (Sudden Doom, high RP)
-         if DKROT_Settings.CD[Current_Spec].RP
-         and (UnitPower("player") > 80
-            or select(7, UnitBuff("PLAYER",spells["Sudden Doom"])) ~= nil) then
-            return DKROT:GetRangeandIcon(icon, spells["Death Coil"])
-         end
-
-         --Festering Strike
-         if GetSpellTexture(spells["Festering Strike"]) ~= nil then
-            if frost <= 0 and blood <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Festering Strike"])
-            end
-         else
-            --Icy Touch
-            if frost <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Icy Touch"])
-            end
-         end
-
-         --Blood Tap with >= 5 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-         and DKROT_Settings.CD[Current_Spec].BT
-         and select(4,UnitBuff("player", spells["Blood Charge"])) ~= nil
-         and select(4,UnitBuff("player", spells["Blood Charge"])) >= 5
-         and (frost >= 0 or unholy >= 0 or blood >= 0) then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
-         end
-
-         --Empower Rune Weapon
-         if GetSpellTexture(spells["Empower Rune Weapon"]) ~= nil
-         and DKROT_Settings.CD[Current_Spec].ERW then
-            if isOffCD(spells["Empower Rune Weapon"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Empower Rune Weapon"])
-            end
-         end
-
-         -- If nothing else can be done
-         return nil
-      end
-
-      --Function to determine rotation for Frost Spec
-      function DKROT:FrostMove(icon)
-         if DKROT_Settings.CD[Current_Spec].AltRot then
-            return DKROT:FrostMoveAlt(icon)
-         end
-
-         --Rune Info
-         local frost, lfrost, fd = DKROT:RuneCDs(SPEC_FROST)
-         local unholy, lunholy, ud = DKROT:RuneCDs(SPEC_UNHOLY)
-         local blood, lblood, bd, lbd = DKROT:RuneCDs(SPEC_BLOOD)
-         local death = DKROT:DeathRunes()
-
-         -- Death Pact
-         if GetSpellTexture(spells["Death Pact"]) ~= nil
-            and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
-         then
-            if isOffCD(spells["Death Pact"]) then
-               return GetSpellTexture(spells["Death Pact"])
-            end
-         end
-
-         if GetSpellTexture(spells["Soul Reaper"]) ~= nil
-            and UnitHealth("target")/UnitHealthMax("target") < 0.35
-         then
-            if isOffCD(spells["Soul Reaper"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Soul Reaper"])
-            end
-         end
-
-         -- Defile
-         if GetSpellTexture(spells["Defile"]) ~= nil then
-            if isOffCD(spells["Defile"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Defile"])
-            end
-         end
-
-         --Diseases
-         local disease, move = DKROT:GetDisease(icon)
-         if disease then return move end
-         local bloodCharges = select(4, UnitBuff("player", spells["Blood Charge"]))
-
-         -- Breath of Sindragosa
-         if GetSpellTexture(spells["Breath of Sindragosa"]) ~= nil and UnitPower("player") > 30 then
-            if isOffCD(spells["Breath of Sindragosa"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Breath of Sindragosa"])
-            end
-         end
-
-         --Obliterate with killing machine or runes overcaped
-         if GetSpellTexture(spells["Obliterate"]) ~= nil
-            and select(1,IsUsableSpell(spells["Obliterate"]))
-            and (select(7,UnitBuff("player", spells["Killing Machine"])) ~= nil
-            or (lfrost <= 0 or lunholy <= 0 or (lblood <= 0 and lbd)))
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Obliterate"])
-         end
-
-         --Blood Tap with >= 11 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 11
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
-         end
-
-         --Frost Strike if rp overcaped
-         if DKROT_Settings.CD[Current_Spec].RP and UnitPower("player") > 76 then
-            return DKROT:GetRangeandIcon(icon, spells["Frost Strike"])
-         end
-
-         --Obliterate
-         if GetSpellTexture(spells["Obliterate"]) ~= nil then
-            if select(1,IsUsableSpell(spells["Obliterate"])) then
-               return DKROT:GetRangeandIcon(icon, spells["Obliterate"])
-            end
-         else
-            --Howling Blast
-            if frost <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Howling Blast"])
-            end
-
-            --Plague Strike
-            if unholy <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Plague Strike"])
-            end
-         end
-
-         --Rime Howling Blast
-         if select(7,UnitBuff("player", spells["Freezing Fog"])) ~= nil then
-            return DKROT:GetRangeandIcon(icon, spells["Howling Blast"])
-         end
-
-         --Frost Strike
-         if DKROT_Settings.CD[Current_Spec].RP and UnitPower("player") >= 25 then
-            return DKROT:GetRangeandIcon(icon, spells["Frost Strike"])
-         end
-
-         --Blood Tap with >= 5 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 5
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
-         end
-
-         --Empower Rune Weapon
-         if GetSpellTexture(spells["Empower Rune Weapon"]) ~= nil
-         and DKROT_Settings.CD[Current_Spec].ERW then
-            if isOffCD(spells["Empower Rune Weapon"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Empower Rune Weapon"])
-            end
-         end
-
-         -- If nothing else can be done
-         return nil
-      end
-
-      --Dual-Wield rotaton
-      function DKROT:FrostMoveAlt(icon)
-
-         --Rune Info
-         local frost, lfrost = DKROT:RuneCDs(SPEC_FROST)
-         local unholy, lunholy, ud = DKROT:RuneCDs(SPEC_UNHOLY)
-         local blood, lblood = DKROT:RuneCDs(SPEC_BLOOD)
-         local death = DKROT:DeathRunes()
-         local bloodCharges = select(4, UnitBuff("player", spells["Blood Charge"]))
-
-         -- Death Pact
-         if GetSpellTexture(spells["Death Pact"]) ~= nil
-            and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
-         then
-            if isOffCD(spells["Death Pact"]) then
-               return GetSpellTexture(spells["Death Pact"])
-            end
-         end
-
-         --Soul Reaper
-         if GetSpellTexture(spells["Soul Reaper"]) ~= nil
-            and (death >= 1 or frost <= 0)
-            and UnitHealth("target")/UnitHealthMax("target") < 0.35
-         then
-            if isOffCD(spells["Soul Reaper"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Soul Reaper"])
-            end
-         end
-
-         -- Defile
-         if GetSpellTexture(spells["Defile"]) ~= nil then
-            if isOffCD(spells["Defile"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Defile"])
-            end
-         end
-
-         -- Breath of Sindragosa
-         if GetSpellTexture(spells["Breath of Sindragosa"]) ~= nil and UnitPower("player") > 30 then
-            if isOffCD(spells["Breath of Sindragosa"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Breath of Sindragosa"])
-            end
-         end
-
-         --Blood Tap with >= 11 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 11
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
-         end
-
-         --Frost Strike if Killing Machine is procced
-         if DKROT_Settings.CD[Current_Spec].RP
-            and UnitPower("player") >= 25
-            and select(7,UnitBuff("player", spells["Killing Machine"])) ~= nil
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Frost Strike"])
-         end
-
-         --Frost Strike if RP capped
-         if DKROT_Settings.CD[Current_Spec].RP and UnitPower("player") > 88 then
-            return DKROT:GetRangeandIcon(icon, spells["Frost Strike"])
-         end
-
-         --Diseases
-         local disease, move = DKROT:GetDisease(icon)
-         if disease then return move end
-
-         --Death and Decay
-         if GetSpellTexture(spells["Death and Decay"]) ~= nil
-            and DKROT_Settings.MoveAltDND and lunholy <= 0
-         then
-            if isOffCD(spells["Death and Decay"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Death and Decay"])
-            end
-         end
-
-         --Howling Blast with both frost or both death off cooldown
-         if lblood <= 0 or lfrost <= 0 then
-            return DKROT:GetRangeandIcon(icon, spells["Howling Blast"])
-         end
-
-         --Obliterate when Killing Machine is procced and both Unholy Runes are off cooldown
-         if GetSpellTexture(spells["Obliterate"])~=nil
-            and select(1,IsUsableSpell(spells["Obliterate"]))
-            and lunholy <= 0
-            and select(7,UnitBuff("player", spells["Killing Machine"])) ~= nil
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Obliterate"])
-         end
-
-         --Howling Blast if Rime procced
-         if select(7,UnitBuff("player", spells["Freezing Fog"])) ~= nil then
-            return DKROT:GetRangeandIcon(icon, spells["Howling Blast"])
-         end
-
-         --Obliterate when second Unholy Rune is nearly off cooldown
-         if GetSpellTexture(spells["Obliterate"])~=nil then
-            if lunholy <= 2 and not ud and (frost <= 0 or blood <= 0) then
-               return DKROT:GetRangeandIcon(icon, spells["Obliterate"])
-            end
-         else --Plague Strike
-            if unholy <= 0 then
-               return DKROT:GetRangeandIcon(icon, spells["Plague Strike"])
-            end
-         end
-
-         --Howling Blast
-         if death >= 1 or frost <= 0 then
-            return DKROT:GetRangeandIcon(icon, spells["Howling Blast"])
-         end
-
-         --Blood Tap with >= 5 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 5
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
-         end
-
-         --Frost Strike
-         if DKROT_Settings.CD[Current_Spec].RP and UnitPower("player") > 39 then
-            return DKROT:GetRangeandIcon(icon, spells["Frost Strike"])
-         end
-
-         --Empower Rune Weapon
-         if GetSpellTexture(spells["Empower Rune Weapon"]) ~= nil
-         and DKROT_Settings.CD[Current_Spec].ERW then
-            if isOffCD(spells["Empower Rune Weapon"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Empower Rune Weapon"])
-            end
-         end
-
-         --If nothing else can be done
-         return nil
-      end
-
-      --Function to determine rotation for Blood Spec
-      function DKROT:BloodMove(icon)
-         --Rune Info
-         local frost, lfrost, fd = DKROT:RuneCDs(SPEC_FROST)
-         local unholy, lunholy, ud = DKROT:RuneCDs(SPEC_UNHOLY)
-         local blood, lblood = DKROT:RuneCDs(SPEC_BLOOD)
-         local death = DKROT:DeathRunes()
-         local bloodCharges = select(4,UnitBuff("player", spells["Blood Charge"]))
-
-         -- Death Pact
-         if GetSpellTexture(spells["Death Pact"]) ~= nil
-            and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
-         then
-            if isOffCD(spells["Death Pact"]) then
-               return GetSpellTexture(spells["Death Pact"])
-            end
-         end
-
-         --Bone Shield
-         if GetSpellTexture(spells["Bone Shield"]) ~= nil
-         and select(7, UnitBuff("player", spells["Bone Shield"])) == nil   then
-            if isOffCD(spells["Bone Shield"]) then
-               return GetSpellTexture(spells["Bone Shield"])
-            end
-         end
-
-         -- Defile
-         if GetSpellTexture(spells["Defile"]) ~= nil then
-            if isOffCD(spells["Defile"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Defile"])
-            end
-         end
-
-         --Soul Reaper
-         if lblood <= 2 and GetSpellTexture(spells["Soul Reaper"]) ~= nil
-            and UnitHealth("target")/UnitHealthMax("target") < 0.35
-         then
-            if isOffCD(spells["Soul Reaper"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Soul Reaper"])
-            end
-         end
-
-         --Diseases
-         local disease, move = DKROT:GetDisease(icon)
-         if disease then return move end
-
-         --Death Strike
-         if GetSpellTexture(spells["Death Strike"]) ~= nil
-         and select(1,IsUsableSpell(spells["Death Strike"])) then
-            return DKROT:GetRangeandIcon(icon, spells["Death Strike"])
-         end
-
-         -- Breath of Sindragosa
-         if GetSpellTexture(spells["Breath of Sindragosa"]) ~= nil and UnitPower("player") > 30 then
-            if isOffCD(spells["Breath of Sindragosa"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Breath of Sindragosa"])
-            end
-         end
-
-         --Blood Tap with >= 11 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 11
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
-         end
-
-         --Blood Boil if we have a blood rune
-         if GetSpellTexture(spells["Blood Boil"]) and blood <= 0 then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Boil"])
-         end
-
-         --Death Coil
-         if UnitPower("player") >= 40 then
-            return DKROT:GetRangeandIcon(icon, spells["Death Coil"])
-         end
-
-         --Crimson Scourge BB
-         if select(7,UnitBuff("player", spells["Crimson Scourge"])) ~= nil then
-            if DKROT_Settings.MoveAltDND then
-               --Death and Decay
-               if GetSpellTexture(spells["Death and Decay"]) ~= nil then
-                  if isOffCD(spells["Death and Decay"]) then
-                     DKROT.Move.AOE:SetAlpha(1)
-                     DKROT.Move.AOE.Icon:SetTexture(GetSpellTexture(spells["Death and Decay"]))
-                  end
-               end
-            end
-            return DKROT:GetRangeandIcon(icon, spells["Blood Boil"])
-         end
-
-         --Blood Tap with >= 5 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 5
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
-         end
-
-         --Empower Rune Weapon if we have runes to activate and we're not RP capped
-         if GetSpellTexture(spells["Empower Rune Weapon"]) ~= nil
-            and DKROT_Settings.CD[Current_Spec].ERW
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-            and UnitPower("player") < 80
-         then
-            if isOffCD(spells["Empower Rune Weapon"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Empower Rune Weapon"])
-            end
-         end
-
-         --If nothing else can be done
-         return nil
-      end
-
       --Function to determine rotation for No Spec
       function DKROT:BlankMove(icon)
          --Rune Info
-         local frost = DKROT:RuneCDs(SPEC_FROST)
-         local unholy = DKROT:RuneCDs(SPEC_UNHOLY)
-         local blood = DKROT:RuneCDs(SPEC_BLOOD)
+         local frost = DKROT:RuneCDs(DKROT.SPECS.FROST)
+         local unholy = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+         local blood = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
          local death = DKROT:DeathRunes()
-         local bloodCharges = select(4, UnitBuff("player", spells["Blood Charge"]))
+         local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
 
          --Diseases
          local disease, move = DKROT:GetDisease(icon)
          if disease then   return move   end
 
          -- Death Pact
-         if GetSpellTexture(spells["Death Pact"]) ~= nil
+         if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
             and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
          then
-            if isOffCD(spells["Death Pact"]) then
-               return GetSpellTexture(spells["Death Pact"])
+            if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
+               return GetSpellTexture(DKROT.spells["Death Pact"])
             end
          end
 
          --Blood Tap with >= 11 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
+         if GetSpellTexture(DKROT.spells["Blood Tap"])
+            and DKROT_Settings.CD[DKROT.Current_Spec].BT
             and bloodCharges ~= nil and bloodCharges >= 11
             and (frost >= 0 or unholy >= 0 or blood >= 0)
          then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
          end
 
          --Death Coil if overcaped RP
-         if DKROT_Settings.CD[Current_Spec].RP
+         if DKROT_Settings.CD[DKROT.Current_Spec].RP
          and UnitPower("player") > 80 then
-            return DKROT:GetRangeandIcon(icon, spells["Death Coil"])
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
          end
 
          --Death Strike
-         if GetSpellTexture(spells["Death Strike"]) then
-            if select(1,IsUsableSpell(spells["Death Strike"])) then
-               return DKROT:GetRangeandIcon(icon, spells["Death Strike"])
+         if GetSpellTexture(DKROT.spells["Death Strike"]) then
+            if select(1,IsUsableSpell(DKROT.spells["Death Strike"])) then
+               return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Strike"])
             end
-         elseif select(1,IsUsableSpell(spells["Icy Touch"])) then
-            return DKROT:GetRangeandIcon(icon, spells["Icy Touch"])
-         elseif select(1,IsUsableSpell(spells["Plague Strike"])) then
-            return DKROT:GetRangeandIcon(icon, spells["Plague Strike"])
+         elseif select(1,IsUsableSpell(DKROT.spells["Icy Touch"])) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Icy Touch"])
+         elseif select(1,IsUsableSpell(DKROT.spells["Plague Strike"])) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
          end
 
          --Blood Boil
-         if select(1,IsUsableSpell(spells["Blood Boil"])) then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Boil"])
+         if select(1,IsUsableSpell(DKROT.spells["Blood Boil"])) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Boil"])
          end
 
          --Death Coil
-         if DKROT_Settings.CD[Current_Spec].RP and UnitPower("player") >= 40 then
-            return DKROT:GetRangeandIcon(icon, spells["Death Coil"])
+         if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") >= 40 then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
          end
 
          --Blood Tap with >= 5 Charges
-         if GetSpellTexture(spells["Blood Tap"])
-            and DKROT_Settings.CD[Current_Spec].BT
+         if GetSpellTexture(DKROT.spells["Blood Tap"])
+            and DKROT_Settings.CD[DKROT.Current_Spec].BT
             and bloodCharges ~= nil and bloodCharges >= 5
             and (frost >= 0 or unholy >= 0 or blood >= 0)
          then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Tap"])
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
          end
 
          --Empower Rune Weapon
-         if GetSpellTexture(spells["Empower Rune Weapon"]) ~= nil
-         and DKROT_Settings.CD[Current_Spec].ERW then
-            if isOffCD(spells["Empower Rune Weapon"]) then
-               return DKROT:GetRangeandIcon(icon, spells["Empower Rune Weapon"])
+         if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
+         and DKROT_Settings.CD[DKROT.Current_Spec].ERW then
+            if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
+               return DKROT:GetRangeandIcon(icon, DKROT.spells["Empower Rune Weapon"])
             end
          end
 
@@ -2286,19 +1600,19 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          -- > SS > BB + IT
 
          --Rune Info
-         local frost, lfrost, fd, lfd = DKROT:RuneCDs(SPEC_FROST)
-         local unholy, lunholy = DKROT:RuneCDs(SPEC_UNHOLY)
-         local blood, lblood, bd, lbd = DKROT:RuneCDs(SPEC_BLOOD)
+         local frost, lfrost, fd, lfd = DKROT:RuneCDs(DKROT.SPECS.FROST)
+         local unholy, lunholy = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+         local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
          local death = DKROT:DeathRunes()
 
          --AOE:Death and Decay
-         if DKROT:QuickAOESpellCheck(spells["Death and Decay"]) and (unholy <= 0 or death >= 1) then
-            return DKROT:GetRangeandIcon(icon, spells["Death and Decay"])
+         if DKROT:QuickAOESpellCheck(DKROT.spells["Death and Decay"]) and (unholy <= 0 or death >= 1) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Death and Decay"])
          end
 
          --AOE:Blood Boil
-         if DKROT:QuickAOESpellCheck(spells["Blood Boil"]) and (blood <= 0 or death >= 1) then
-            return DKROT:GetRangeandIcon(icon, spells["Blood Boil"])
+         if DKROT:QuickAOESpellCheck(DKROT.spells["Blood Boil"]) and (blood <= 0 or death >= 1) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Boil"])
          end
 
          --Scourge Strike
@@ -2307,9 +1621,9 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          end
 
          --AOE:Death Coil
-         if DKROT_Settings.CD[Current_Spec].RP
+         if DKROT_Settings.CD[DKROT.Current_Spec].RP
          and (UnitPower("player") >= 40
-            or select(7, UnitBuff("PLAYER",spells["Sudden Doom"])) ~= nil) then
+            or select(7, UnitBuff("PLAYER",DKROT.spells["Sudden Doom"])) ~= nil) then
             return DKROT:GetRangeandIcon(icon, nil)
          end
 
@@ -2320,44 +1634,44 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       function DKROT:FrostAOEMove(icon)
 
          --Rune Info
-         local frost, lfrost, fd, lfd = DKROT:RuneCDs(SPEC_FROST)
-         local unholy, lunholy, ud, lud = DKROT:RuneCDs(SPEC_UNHOLY)
-         local blood, lblood = DKROT:RuneCDs(SPEC_BLOOD)
+         local frost, lfrost, fd, lfd = DKROT:RuneCDs(DKROT.SPECS.FROST)
+         local unholy, lunholy, ud, lud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+         local blood, lblood = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
          local death = DKROT:DeathRunes()
 
          --AOE:Howling Blast if both Frost runes and/or both Death runes are up
-         if DKROT:QuickAOESpellCheck(spells["Howling Blast"]) and ((lfrost <= 0) or (lblood <= 0) or (lunholy <= 0 and lud)) then
-            return DKROT:GetRangeandIcon(icon, spells["Howling Blast"])
+         if DKROT:QuickAOESpellCheck(DKROT.spells["Howling Blast"]) and ((lfrost <= 0) or (lblood <= 0) or (lunholy <= 0 and lud)) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
          end
 
          --AOE:DnD if both Unholy Runes are up
-         if DKROT:QuickAOESpellCheck(spells["Death and Decay"]) and (lunholy <= 0) then
-            return DKROT:GetRangeandIcon(icon, spells["Death and Decay"])
+         if DKROT:QuickAOESpellCheck(DKROT.spells["Death and Decay"]) and (lunholy <= 0) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Death and Decay"])
          end
 
          --AOE:Frost Strike if RP capped
-         if DKROT:QuickAOESpellCheck(spells["Frost Strike"]) and (UnitPower("player") > 88) then
+         if DKROT:QuickAOESpellCheck(DKROT.spells["Frost Strike"]) and (UnitPower("player") > 88) then
             return DKROT:GetRangeandIcon(icon, nil)
          end
 
          --AOE:Howling Blast
-         if DKROT:QuickAOESpellCheck(spells["Howling Blast"]) and (frost <= 0 or death >= 1) then
-            return DKROT:GetRangeandIcon(icon, spells["Howling Blast"])
+         if DKROT:QuickAOESpellCheck(DKROT.spells["Howling Blast"]) and (frost <= 0 or death >= 1) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
          end
 
          --AOE:DnD
-         if DKROT:QuickAOESpellCheck(spells["Death and Decay"]) and (unholy <= 0) then
-            return DKROT:GetRangeandIcon(icon, spells["Death and Decay"])
+         if DKROT:QuickAOESpellCheck(DKROT.spells["Death and Decay"]) and (unholy <= 0) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Death and Decay"])
          end
 
          --AOE:Frost Strike
-         if DKROT:QuickAOESpellCheck(spells["Frost Strike"]) and UnitPower("player") >= 20 then
+         if DKROT:QuickAOESpellCheck(DKROT.spells["Frost Strike"]) and UnitPower("player") >= 20 then
             return DKROT:GetRangeandIcon(icon, nil)
          end
 
          --AOE:PS
-         if DKROT:QuickAOESpellCheck(spells["Plague Strike"]) and (unholy <= 0) then
-            return DKROT:GetRangeandIcon(icon, spells["Plague Strike"])
+         if DKROT:QuickAOESpellCheck(DKROT.spells["Plague Strike"]) and (unholy <= 0) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
          end
 
          return nil
@@ -2373,10 +1687,10 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    --Function to check spec and presence
    function DKROT:CheckSpec()
       --Set all settings to default
-      Current_Spec = SPEC_UNKNOWN
-      if GetSpecialization() == 1 then Current_Spec = SPEC_BLOOD
-      elseif GetSpecialization() == 2 then Current_Spec = SPEC_FROST
-      elseif GetSpecialization() == 3 then Current_Spec = SPEC_UNHOLY
+      DKROT.Current_Spec = DKROT.SPECS.UNKNOWN
+      if GetSpecialization() == 1 then DKROT.Current_Spec = DKROT.SPECS.BLOOD
+      elseif GetSpecialization() == 2 then DKROT.Current_Spec = DKROT.SPECS.FROST
+      elseif GetSpecialization() == 3 then DKROT.Current_Spec = DKROT.SPECS.UNHOLY
       end
 
       --Presence
@@ -2388,7 +1702,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          end
       end
 
-      if debugg then print("DKROT:Check Spec - "..Current_Spec)end
+      if debugg then print("DKROT:Check Spec - "..DKROT.Current_Spec)end
       DKROT:OptionsRefresh()
    end
 
@@ -2424,12 +1738,12 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if debugg then print("DKROT:Initialize - Version "..DKROT_Settings.Version)end
 
       if DKROT_Settings.DT.Combat or not DKROT_Settings.DT.Enable then
-         DKROT:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+         DKROT.MainFrame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
       else
-         DKROT:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+         DKROT.MainFrame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
       end
 
-      DKROT:SetAlpha(0)
+      DKROT.MainFrame:SetAlpha(0)
       DKROT:CreateCDs()
       DKROT:CreateUI()
 
@@ -2467,7 +1781,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       InterfaceOptions_AddCategory(DKROT_DTPanel)
       InterfaceOptions_AddCategory(DKROT_ABOUTPanel)
 
-      DKROT_CDRPanel_DG_Text:SetText(spells["Death Grip"])
+      DKROT_CDRPanel_DG_Text:SetText(DKROT.spells["Death Grip"])
 
       --Initalize all dropdowns
       UIDropDownMenu_Initialize(DKROT_FramePanel_Rune_DD, DKROT_Rune_DD_OnLoad)
@@ -2492,14 +1806,14 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
 
    -----Events-----
    --Register Events
-   DKROT:RegisterEvent("PLAYER_TALENT_UPDATE")
-   DKROT:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED")
+   DKROT.MainFrame:RegisterEvent("PLAYER_TALENT_UPDATE")
+   DKROT.MainFrame:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED")
    --DKROT:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
    --DKROT:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
 
    --Function to be called when events triggered
    local slottimer = 0
-   DKROT:SetScript("OnEvent", function(_, e, ...)
+   DKROT.MainFrame:SetScript("OnEvent", function(_, e, ...)
       -- Delayed addon initialization due to combat lockdown
       if loaded then
          --if debugg then print("DKROT:Event "..e)end
@@ -2523,19 +1837,19 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                      DKROT.DT.Unit[targetguid].Name = select(3, string.find(targetName, "(.-)-")) or targetName
                   end
 
-                  if DKROT.DT.Unit[targetguid].Spells[spellName] == nil then
+                  if DKROT.DT.Unit[targetguid].DKROT.spells[spellName] == nil then
                      DKROT.DT.Unit[targetguid].NumDots = DKROT.DT.Unit[targetguid].NumDots + 1
                   end
 
-                  if spellName == spells["Death and Decay"] then
-                     DKROT.DT.Unit[targetguid].Spells[spellName] = select(1, GetSpellCooldown(spellName)) + 10
+                  if spellName == DKROT.spells["Death and Decay"] then
+                     DKROT.DT.Unit[targetguid].DKROT.spells[spellName] = select(1, GetSpellCooldown(spellName)) + 10
                   else
-                     DKROT.DT.Unit[targetguid].Spells[spellName] = DTspells[spellName][2] + curtime
+                     DKROT.DT.Unit[targetguid].DKROT.spells[spellName] = DTDKROT.spells[spellName][2] + curtime
                   end
 
                elseif (event == "SPELL_AURA_REMOVED") then
                   if DKROT.DT.Unit[targetguid] ~= nil and  DKROT.DT.Unit[targetguid][spellName] ~= nil then
-                      DKROT.DT.Unit[targetguid].Spells[spellName] = nil
+                      DKROT.DT.Unit[targetguid].DKROT.spells[spellName] = nil
                       DKROT.DT.Unit[targetguid].NumDots = DKROT.DT.Unit[targetguid].NumDots - 1
                   end
                end
@@ -2550,7 +1864,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    local DTupdatetimer = 0
    local DTchecktimer = 0
    local scheduledInit = false
-   DKROT:SetScript("OnUpdate", function()
+   DKROT.MainFrame:SetScript("OnUpdate", function()
       curtime = GetTime()
       --Make sure it only updates at max, once every 0.15 sec
       if (curtime - updatetimer >= 0.08) then
@@ -2568,12 +1882,12 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                   (DKROT_Settings.VScheme ~= DKROT_OPTIONS_FRAME_VIEW_HIDE and UnitCanAttack("player", "target") and (not UnitIsDead("target")))) then
                DKROT:UpdateUI()
                if DKROT_Settings.Locked then
-                  if IsAltKeyDown() then DKROT:EnableMouse(true)
-                  else DKROT:EnableMouse(false) end
+                  if IsAltKeyDown() then DKROT.MainFrame:EnableMouse(true)
+                  else DKROT.MainFrame:EnableMouse(false) end
                end
 
             else
-               DKROT:SetAlpha(0)
+               DKROT.MainFrame:SetAlpha(0)
             end
 
             if resize ~= nil then
@@ -2645,68 +1959,68 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
 
 
          --CD/R
-         DKROT_CDRPanel_Outbreak_Text:SetText(spells["Outbreak"])
-         DKROT_CDRPanel_UB_Text:SetText(spells["Unholy Blight"])
-         DKROT_CDRPanel_PL_Text:SetText(spells["Plague Leech"])
-         DKROT_CDRPanel_ERW_Text:SetText(spells["Empower Rune Weapon"])
-         DKROT_CDRPanel_BT_Text:SetText(spells["Blood Tap"])
-         DKROT_CDRPanel_DP_Text:SetText(spells["Death Pact"])
-         if (Current_Spec == SPEC_UNHOLY) then
+         DKROT_CDRPanel_Outbreak_Text:SetText(DKROT.spells["Outbreak"])
+         DKROT_CDRPanel_UB_Text:SetText(DKROT.spells["Unholy Blight"])
+         DKROT_CDRPanel_PL_Text:SetText(DKROT.spells["Plague Leech"])
+         DKROT_CDRPanel_ERW_Text:SetText(DKROT.spells["Empower Rune Weapon"])
+         DKROT_CDRPanel_BT_Text:SetText(DKROT.spells["Blood Tap"])
+         DKROT_CDRPanel_DP_Text:SetText(DKROT.spells["Death Pact"])
+         if (DKROT.Current_Spec == DKROT.SPECS.UNHOLY) then
             DKROT_CDRPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_UNHOLY)
             DKROT_CDPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_UNHOLY)
             DKROT_CDRPanel_AltRot_Text:SetText(DKROT_OPTIONS_CDR_ALT_ROT.." ("..DKROT_OPTIONS_CDR_ALT_ROT_UNHOLY..")")
-            DKROT_CDRPanel_AltRot:SetChecked(DKROT_Settings.CD[Current_Spec].AltRot)
-         elseif (Current_Spec == SPEC_FROST) then
+            DKROT_CDRPanel_AltRot:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].AltRot)
+         elseif (DKROT.Current_Spec == DKROT.SPECS.FROST) then
             DKROT_CDRPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_FROST)
             DKROT_CDPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_FROST)
             DKROT_CDRPanel_AltRot_Text:SetText(DKROT_OPTIONS_CDR_ALT_ROT.." ("..DKROT_OPTIONS_CDR_ALT_ROT_FROST..")")
-            DKROT_CDRPanel_AltRot:SetChecked(DKROT_Settings.CD[Current_Spec].AltRot)
-         elseif (Current_Spec == SPEC_BLOOD) then
+            DKROT_CDRPanel_AltRot:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].AltRot)
+         elseif (DKROT.Current_Spec == DKROT.SPECS.BLOOD) then
             DKROT_CDRPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_BLOOD)
             DKROT_CDPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_BLOOD)
             DKROT_CDRPanel_AltRot_Text:SetText(DKROT_OPTIONS_CDR_ALT_ROT.." ("..DKROT_OPTIONS_CDR_ALT_ROT_BLOOD..")")
             DKROT_CDRPanel_AltRot:Disable()
-            DKROT_CDRPanel_AltRot:SetChecked(DKROT_Settings.CD[Current_Spec].AltRot)
+            DKROT_CDRPanel_AltRot:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].AltRot)
          else
-            DKROT_CDRPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_None)
-            DKROT_CDPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_None)
+            DKROT_CDRPanel_Title_Spec:SetText(DKROT_OPTIONS_DKROT_SPEC_None)
+            DKROT_CDPanel_Title_Spec:SetText(DKROT_OPTIONS_DKROT_SPEC_None)
          end
 
          --Disease Dropdown
-         UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Diseases_DD, DKROT_Settings.CD[Current_Spec].DiseaseOption)
+         UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Diseases_DD, DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption)
          local text
-         if DKROT_Settings.CD[Current_Spec].DiseaseOption == DISEASE_BOTH then text = DKROT_OPTIONS_CDR_DISEASES_DD_BOTH
-         elseif DKROT_Settings.CD[Current_Spec].DiseaseOption == DISEASE_ONE then text = DKROT_OPTIONS_CDR_DISEASES_DD_ONE
+         if DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption == DISEASE_BOTH then text = DKROT_OPTIONS_CDR_DISEASES_DD_BOTH
+         elseif DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption == DISEASE_ONE then text = DKROT_OPTIONS_CDR_DISEASES_DD_ONE
          else text =   DKROT_OPTIONS_CDR_DISEASES_DD_NONE end
          UIDropDownMenu_SetText(DKROT_CDRPanel_Diseases_DD, text)
 
-         DKROT_CDRPanel_Outbreak:SetChecked(DKROT_Settings.CD[Current_Spec].Outbreak)
-         DKROT_CDRPanel_UB:SetChecked(DKROT_Settings.CD[Current_Spec].UB)
-         DKROT_CDRPanel_PL:SetChecked(DKROT_Settings.CD[Current_Spec].PL)
-         DKROT_CDRPanel_ERW:SetChecked(DKROT_Settings.CD[Current_Spec].ERW)
-         DKROT_CDRPanel_BT:SetChecked(DKROT_Settings.CD[Current_Spec].BT)
-         DKROT_CDRPanel_DP:SetChecked(DKROT_Settings.CD[Current_Spec].DP)
-         DKROT_CDRPanel_IRP:SetChecked(DKROT_Settings.CD[Current_Spec].RP)
+         DKROT_CDRPanel_Outbreak:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].Outbreak)
+         DKROT_CDRPanel_UB:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].UB)
+         DKROT_CDRPanel_PL:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].PL)
+         DKROT_CDRPanel_ERW:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].ERW)
+         DKROT_CDRPanel_BT:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].BT)
+         DKROT_CDRPanel_DP:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].DP)
+         DKROT_CDRPanel_IRP:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].RP)
          DKROT_CDRPanel_MoveAltInterrupt:SetChecked(DKROT_Settings.MoveAltInterrupt)
          DKROT_CDRPanel_MoveAltAOE:SetChecked(DKROT_Settings.MoveAltAOE)
          DKROT_CDRPanel_MoveAltDND:SetChecked(DKROT_Settings.MoveAltDND)
          DKROT_CDRPanel_DG:SetChecked(DKROT_Settings.DG)
-         DKROT_CDRPanel_DD_CD1:SetChecked(DKROT_Settings.CD[Current_Spec][1])
-         DKROT_CDRPanel_DD_CD2:SetChecked(DKROT_Settings.CD[Current_Spec][2])
-         DKROT_CDRPanel_DD_CD3:SetChecked(DKROT_Settings.CD[Current_Spec][3])
-         DKROT_CDRPanel_DD_CD4:SetChecked(DKROT_Settings.CD[Current_Spec][4])
+         DKROT_CDRPanel_DD_CD1:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec][1])
+         DKROT_CDRPanel_DD_CD2:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec][2])
+         DKROT_CDRPanel_DD_CD3:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec][3])
+         DKROT_CDRPanel_DD_CD4:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec][4])
 
          --Priority Dropdown
-         if DKROT_Settings.CD[Current_Spec]["DKROT_CDRPanel_DD_Priority"] ~= nil and DKROT_Settings.CD[Current_Spec]["DKROT_CDRPanel_DD_Priority"][1] ~= nil then
-            UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_DD_Priority, DKROT_Settings.CD[Current_Spec]["DKROT_CDRPanel_DD_Priority"][1]..((DKROT_Settings.CD[Current_Spec]["DKROT_CDRPanel_DD_Priority"][IS_BUFF] and " (Buff)") or ""))
-            UIDropDownMenu_SetText(DKROT_CDRPanel_DD_Priority, DKROT_Settings.CD[Current_Spec]["DKROT_CDRPanel_DD_Priority"][1]..((DKROT_Settings.CD[Current_Spec]["DKROT_CDRPanel_DD_Priority"][IS_BUFF] and " (Buff)") or ""))
+         if DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"] ~= nil and DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][1] ~= nil then
+            UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_DD_Priority, DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][1]..((DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][IS_BUFF] and " (Buff)") or ""))
+            UIDropDownMenu_SetText(DKROT_CDRPanel_DD_Priority, DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][1]..((DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][IS_BUFF] and " (Buff)") or ""))
          end
 
          --Cooldown Dropdown
          for i = 1, #CDDisplayList do
-            if _G[CDDisplayList[i]] ~= nil and DKROT_Settings.CD[Current_Spec][CDDisplayList[i]] ~= nil and DKROT_Settings.CD[Current_Spec][CDDisplayList[i]][1] ~= nil then
-               UIDropDownMenu_SetSelectedValue(_G[CDDisplayList[i]], DKROT_Settings.CD[Current_Spec][CDDisplayList[i]][1]..((DKROT_Settings.CD[Current_Spec][CDDisplayList[i]][IS_BUFF] and " (Buff)") or ""))
-               UIDropDownMenu_SetText(_G[CDDisplayList[i]], DKROT_Settings.CD[Current_Spec][CDDisplayList[i]][1]..((DKROT_Settings.CD[Current_Spec][CDDisplayList[i]][IS_BUFF] and " (Buff)") or ""))
+            if _G[CDDisplayList[i]] ~= nil and DKROT_Settings.CD[DKROT.Current_Spec][CDDisplayList[i]] ~= nil and DKROT_Settings.CD[DKROT.Current_Spec][CDDisplayList[i]][1] ~= nil then
+               UIDropDownMenu_SetSelectedValue(_G[CDDisplayList[i]], DKROT_Settings.CD[DKROT.Current_Spec][CDDisplayList[i]][1]..((DKROT_Settings.CD[DKROT.Current_Spec][CDDisplayList[i]][IS_BUFF] and " (Buff)") or ""))
+               UIDropDownMenu_SetText(_G[CDDisplayList[i]], DKROT_Settings.CD[DKROT.Current_Spec][CDDisplayList[i]][1]..((DKROT_Settings.CD[DKROT.Current_Spec][CDDisplayList[i]][IS_BUFF] and " (Buff)") or ""))
             end
          end
 
@@ -2734,16 +2048,16 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          end
          UIDropDownMenu_SetText(DKROT_DTPanel_DD_Threat, text)
 
-         DKROT_DTPanel_DOTS_FF_Text:SetText(spells["Frost Fever"])
-         DKROT_DTPanel_DOTS_FF:SetChecked(DKROT_Settings.DT.Dots[spells["Frost Fever"]])
-         DKROT_DTPanel_DOTS_BP_Text:SetText(spells["Blood Plague"])
-         DKROT_DTPanel_DOTS_BP:SetChecked(DKROT_Settings.DT.Dots[spells["Blood Plague"]])
-         DKROT_DTPanel_DOTS_DD_Text:SetText(spells["Death and Decay"])
-         DKROT_DTPanel_DOTS_DD:SetChecked(DKROT_Settings.DT.Dots[spells["Death and Decay"]])
-         DKROT_DTPanel_DOTS_DF_Text:SetText(spells["Defile"])
-         DKROT_DTPanel_DOTS_DF:SetChecked(DKROT_Settings.DT.Dots[spells["Defile"]])
-         DKROT_DTPanel_DOTS_NP_Text:SetText(spells["Necrotic Plague"])
-         DKROT_DTPanel_DOTS_NP:SetChecked(DKROT_Settings.DT.Dots[spells["Necrotic Plague"]])
+         DKROT_DTPanel_DOTS_FF_Text:SetText(DKROT.spells["Frost Fever"])
+         DKROT_DTPanel_DOTS_FF:SetChecked(DKROT_Settings.DT.Dots[DKROT.spells["Frost Fever"]])
+         DKROT_DTPanel_DOTS_BP_Text:SetText(DKROT.spells["Blood Plague"])
+         DKROT_DTPanel_DOTS_BP:SetChecked(DKROT_Settings.DT.Dots[DKROT.spells["Blood Plague"]])
+         DKROT_DTPanel_DOTS_DD_Text:SetText(DKROT.spells["Death and Decay"])
+         DKROT_DTPanel_DOTS_DD:SetChecked(DKROT_Settings.DT.Dots[DKROT.spells["Death and Decay"]])
+         DKROT_DTPanel_DOTS_DF_Text:SetText(DKROT.spells["Defile"])
+         DKROT_DTPanel_DOTS_DF:SetChecked(DKROT_Settings.DT.Dots[DKROT.spells["Defile"]])
+         DKROT_DTPanel_DOTS_NP_Text:SetText(DKROT.spells["Necrotic Plague"])
+         DKROT_DTPanel_DOTS_NP:SetChecked(DKROT_Settings.DT.Dots[DKROT.spells["Necrotic Plague"]])
 
          --About Options
          local expText = "<html><body>"
@@ -2766,7 +2080,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    end
 
    --Check if options are valid and save them to settings if so
-   function DKROT:OptionsOkay()
+   function DKROT_OptionsOkay()
       if DKROT_Settings ~= nil and (DKROT_Settings.Version ~= nil and DKROT_Settings.Version == DKROT_VERSION) then
          --Frame
          DKROT_Settings.GCD = DKROT_FramePanel_GCD:GetChecked()
@@ -2810,18 +2124,18 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT_Settings.MoveAltAOE = DKROT_CDRPanel_MoveAltAOE:GetChecked()
          DKROT_Settings.MoveAltDND = DKROT_CDRPanel_MoveAltDND:GetChecked()
          DKROT_Settings.DG = DKROT_CDRPanel_DG:GetChecked()
-         DKROT_Settings.CD[Current_Spec].AltRot = DKROT_CDRPanel_AltRot:GetChecked()
-         DKROT_Settings.CD[Current_Spec].Outbreak = DKROT_CDRPanel_Outbreak:GetChecked()
-         DKROT_Settings.CD[Current_Spec].UB = DKROT_CDRPanel_UB:GetChecked()
-         DKROT_Settings.CD[Current_Spec].PL = DKROT_CDRPanel_PL:GetChecked()
-         DKROT_Settings.CD[Current_Spec].ERW = DKROT_CDRPanel_ERW:GetChecked()
-         DKROT_Settings.CD[Current_Spec].BT = DKROT_CDRPanel_BT:GetChecked()
-         DKROT_Settings.CD[Current_Spec].DP = DKROT_CDRPanel_DP:GetChecked()
-         DKROT_Settings.CD[Current_Spec].RP = DKROT_CDRPanel_IRP:GetChecked()
-         DKROT_Settings.CD[Current_Spec][1] = (DKROT_CDRPanel_DD_CD1:GetChecked())
-         DKROT_Settings.CD[Current_Spec][2] = (DKROT_CDRPanel_DD_CD2:GetChecked())
-         DKROT_Settings.CD[Current_Spec][3] = (DKROT_CDRPanel_DD_CD3:GetChecked())
-         DKROT_Settings.CD[Current_Spec][4] = (DKROT_CDRPanel_DD_CD4:GetChecked())
+         DKROT_Settings.CD[DKROT.Current_Spec].AltRot = DKROT_CDRPanel_AltRot:GetChecked()
+         DKROT_Settings.CD[DKROT.Current_Spec].Outbreak = DKROT_CDRPanel_Outbreak:GetChecked()
+         DKROT_Settings.CD[DKROT.Current_Spec].UB = DKROT_CDRPanel_UB:GetChecked()
+         DKROT_Settings.CD[DKROT.Current_Spec].PL = DKROT_CDRPanel_PL:GetChecked()
+         DKROT_Settings.CD[DKROT.Current_Spec].ERW = DKROT_CDRPanel_ERW:GetChecked()
+         DKROT_Settings.CD[DKROT.Current_Spec].BT = DKROT_CDRPanel_BT:GetChecked()
+         DKROT_Settings.CD[DKROT.Current_Spec].DP = DKROT_CDRPanel_DP:GetChecked()
+         DKROT_Settings.CD[DKROT.Current_Spec].RP = DKROT_CDRPanel_IRP:GetChecked()
+         DKROT_Settings.CD[DKROT.Current_Spec][1] = (DKROT_CDRPanel_DD_CD1:GetChecked())
+         DKROT_Settings.CD[DKROT.Current_Spec][2] = (DKROT_CDRPanel_DD_CD2:GetChecked())
+         DKROT_Settings.CD[DKROT.Current_Spec][3] = (DKROT_CDRPanel_DD_CD3:GetChecked())
+         DKROT_Settings.CD[DKROT.Current_Spec][4] = (DKROT_CDRPanel_DD_CD4:GetChecked())
 
          --Disease Timers
          DKROT_Settings.DT.Enable = DKROT_DTPanel_Enable:GetChecked()
@@ -2858,16 +2172,16 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          else
             DKROT_DTPanel_Trans:SetNumber(DKROT_Settings.DTTrans)
          end
-         DKROT_Settings.DT.Dots[spells["Frost Fever"]] = DKROT_DTPanel_DOTS_FF:GetChecked()
-         DKROT_Settings.DT.Dots[spells["Blood Plague"]] = DKROT_DTPanel_DOTS_BP:GetChecked()
-         DKROT_Settings.DT.Dots[spells["Death and Decay"]] = DKROT_DTPanel_DOTS_DD:GetChecked()
-         DKROT_Settings.DT.Dots[spells["Defile"]] = DKROT_DTPanel_DOTS_DF:GetChecked()
-         DKROT_Settings.DT.Dots[spells["Necrotic Plague"]] = DKROT_DTPanel_DOTS_NP:GetChecked()
+         DKROT_Settings.DT.Dots[DKROT.spells["Frost Fever"]] = DKROT_DTPanel_DOTS_FF:GetChecked()
+         DKROT_Settings.DT.Dots[DKROT.spells["Blood Plague"]] = DKROT_DTPanel_DOTS_BP:GetChecked()
+         DKROT_Settings.DT.Dots[DKROT.spells["Death and Decay"]] = DKROT_DTPanel_DOTS_DD:GetChecked()
+         DKROT_Settings.DT.Dots[DKROT.spells["Defile"]] = DKROT_DTPanel_DOTS_DF:GetChecked()
+         DKROT_Settings.DT.Dots[DKROT.spells["Necrotic Plague"]] = DKROT_DTPanel_DOTS_NP:GetChecked()
 
          if DKROT_Settings.DT.Combat or not DKROT_Settings.DT.Enable then
-            DKROT:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+            DKROT.MainFrame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
          else
-            DKROT:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+            DKROT.MainFrame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
          end
 
          -- Change the cooldown spiral edge settings
@@ -2884,7 +2198,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    function DKROT:CooldownDefaults()
       if DKROT_Settings.CD ~= nil then wipe(DKROT_Settings.CD) end
       DKROT_Settings.CD = {
-         [SPEC_UNHOLY] = {
+         [DKROT.SPECS.UNHOLY] = {
             ["DKROT_CDRPanel_DD_Priority"] = {DKROT_OPTIONS_CDR_CD_PRIORITY, nil},
             DiseaseOption = DISEASE_BOTH,
             Outbreak = true,
@@ -2895,21 +2209,21 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             BT = true,
 
             [1] = true,
-            ["DKROT_CDRPanel_DD_CD1_One"] = {spells["Shadow Infusion"], true},
-            ["DKROT_CDRPanel_DD_CD1_Two"] = {spells["Dark Transformation"], true},
+            ["DKROT_CDRPanel_DD_CD1_One"] = {DKROT.spells["Shadow Infusion"], true},
+            ["DKROT_CDRPanel_DD_CD1_Two"] = {DKROT.spells["Dark Transformation"], true},
 
             [2] = true,
-            ["DKROT_CDRPanel_DD_CD2_Two"] = {spells["Sudden Doom"], true},
+            ["DKROT_CDRPanel_DD_CD2_Two"] = {DKROT.spells["Sudden Doom"], true},
 
             [3] = false,
-            ["DKROT_CDRPanel_DD_CD3_One"] = {spells["Summon Gargoyle"], nil},
+            ["DKROT_CDRPanel_DD_CD3_One"] = {DKROT.spells["Summon Gargoyle"], nil},
 
             [4] = false,
             ["DKROT_CDRPanel_DD_CD4_One"] = {DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1, nil},
             ["DKROT_CDRPanel_DD_CD4_Two"] = {DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT2, nil},
          },
 
-         [SPEC_FROST] = {
+         [DKROT.SPECS.FROST] = {
             ["DKROT_CDRPanel_DD_Priority"] = {DKROT_OPTIONS_CDR_CD_PRIORITY, nil},
             DiseaseOption = DISEASE_BOTH,
             Outbreak = true,
@@ -2920,22 +2234,22 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             BT = true,
 
             [1] = true,
-            ["DKROT_CDRPanel_DD_CD1_One"] = {spells["Pillar of Frost"], nil},
-            ["DKROT_CDRPanel_DD_CD1_Two"] = {spells["Pillar of Frost"], true},
+            ["DKROT_CDRPanel_DD_CD1_One"] = {DKROT.spells["Pillar of Frost"], nil},
+            ["DKROT_CDRPanel_DD_CD1_Two"] = {DKROT.spells["Pillar of Frost"], true},
 
             [2] = true,
-            ["DKROT_CDRPanel_DD_CD2_One"] = {spells["Killing Machine"], true},
-            ["DKROT_CDRPanel_DD_CD2_Two"] = {spells["Freezing Fog"], true},
+            ["DKROT_CDRPanel_DD_CD2_One"] = {DKROT.spells["Killing Machine"], true},
+            ["DKROT_CDRPanel_DD_CD2_Two"] = {DKROT.spells["Freezing Fog"], true},
 
             [3] = false,
-            ["DKROT_CDRPanel_DD_CD3_Two"] = {spells["Plague Leech"], nil},
+            ["DKROT_CDRPanel_DD_CD3_Two"] = {DKROT.spells["Plague Leech"], nil},
 
             [4] = false,
             ["DKROT_CDRPanel_DD_CD4_One"] = {DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1, nil},
             ["DKROT_CDRPanel_DD_CD4_Two"] = {DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT2, nil},
          },
 
-         [SPEC_BLOOD] = {
+         [DKROT.SPECS.BLOOD] = {
             ["DKROT_CDRPanel_DD_Priority"] = {DKROT_OPTIONS_CDR_CD_PRIORITY, nil},
             DiseaseOption = DISEASE_BOTH,
             Outbreak = true,
@@ -2946,23 +2260,23 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             BT = true,
 
             [1] = true,
-            ["DKROT_CDRPanel_DD_CD1_One"] = {spells["Bone Shield"], true},
-            ["DKROT_CDRPanel_DD_CD1_Two"] = {spells["Vampiric Blood"], nil},
+            ["DKROT_CDRPanel_DD_CD1_One"] = {DKROT.spells["Bone Shield"], true},
+            ["DKROT_CDRPanel_DD_CD1_Two"] = {DKROT.spells["Vampiric Blood"], nil},
 
             [2] = true,
-            ["DKROT_CDRPanel_DD_CD2_One"] = {spells["Rune Tap"], nil},
-            ["DKROT_CDRPanel_DD_CD2_Two"] = {spells["Scent of Blood"], true},
+            ["DKROT_CDRPanel_DD_CD2_One"] = {DKROT.spells["Rune Tap"], nil},
+            ["DKROT_CDRPanel_DD_CD2_Two"] = {DKROT.spells["Scent of Blood"], true},
 
             [3] = false,
-            ["DKROT_CDRPanel_DD_CD3_One"] = {spells["Blood Shield"], true},
-            ["DKROT_CDRPanel_DD_CD3_Two"] = {spells["Blood Charge"], true},
+            ["DKROT_CDRPanel_DD_CD3_One"] = {DKROT.spells["Blood Shield"], true},
+            ["DKROT_CDRPanel_DD_CD3_Two"] = {DKROT.spells["Blood Charge"], true},
 
             [4] = false,
             ["DKROT_CDRPanel_DD_CD4_One"] = {DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1, nil},
             ["DKROT_CDRPanel_DD_CD4_Two"] = {DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT2, nil},
          },
 
-         [SPEC_UNKNOWN] = {
+         [DKROT.SPECS.UNKNOWN] = {
             ["DKROT_CDRPanel_DD_Priority"] = {DKROT_OPTIONS_CDR_CD_PRIORITY, nil},
             DiseaseOption = DISEASE_BOTH,
             Outbreak = true,
@@ -2973,14 +2287,14 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             BT = true,
 
             [1] = true,
-            ["DKROT_CDRPanel_DD_CD1_Two"] = {spells["Blood Charge"], true},
+            ["DKROT_CDRPanel_DD_CD1_Two"] = {DKROT.spells["Blood Charge"], true},
 
             [2] = true,
-            ["DKROT_CDRPanel_DD_CD2_One"] = {spells["Raise Dead"], nil},
-            ["DKROT_CDRPanel_DD_CD2_Two"] = {spells["Army of the Dead"], nil},
+            ["DKROT_CDRPanel_DD_CD2_One"] = {DKROT.spells["Raise Dead"], nil},
+            ["DKROT_CDRPanel_DD_CD2_Two"] = {DKROT.spells["Army of the Dead"], nil},
 
             [3] = false,
-            ["DKROT_CDRPanel_DD_CD3_Two"] = {spells["Blood Tap"], nil},
+            ["DKROT_CDRPanel_DD_CD3_Two"] = {DKROT.spells["Blood Tap"], nil},
 
             [4] = false,
             ["DKROT_CDRPanel_DD_CD4_One"] = {DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1, nil},
@@ -2993,7 +2307,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    function DKROT:CheckSettings()
       if debugg then print("DKROT:Check Settings Start")end
 
-      local specs = {SPEC_UNKNOWN, SPEC_BLOOD, SPEC_FROST, SPEC_UNHOLY}
+      local specs = {DKROT.SPECS.UNKNOWN, DKROT.SPECS.BLOOD, DKROT.SPECS.FROST, DKROT.SPECS.UNHOLY}
       local spots = {"Priority", "CD1_One", "CD1_Two", "CD2_One", "CD2_Two", "CD3_One", "CD3_Two", "CD4_One", "CD4_Two"}
 
       --Defaults
@@ -3052,9 +2366,9 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if DKROT_Settings.DT.Threat == nil then DKROT_Settings.DT.Threat = THREAT_ANALOG end
       if DKROT_Settings.DT.Dots == nil then
          DKROT_Settings.DT.Dots = {}
-         DKROT_Settings.DT.Dots[spells["Frost Fever"]] = true
-         DKROT_Settings.DT.Dots[spells["Blood Plague"]] = true
-         DKROT_Settings.DT.Dots[spells["Death and Decay"]] = true
+         DKROT_Settings.DT.Dots[DKROT.spells["Frost Fever"]] = true
+         DKROT_Settings.DT.Dots[DKROT.spells["Blood Plague"]] = true
+         DKROT_Settings.DT.Dots[DKROT.spells["Death and Decay"]] = true
       end
 
       --Frame Location
@@ -3193,19 +2507,19 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       info = {}
       info.text = DKROT_OPTIONS_CDR_DISEASES_DD_BOTH
       info.value = DISEASE_BOTH
-      info.func = function() DKROT_Settings.CD[Current_Spec].DiseaseOption = DISEASE_BOTH;UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Diseases_DD,  DKROT_Settings.CD[Current_Spec].DiseaseOption); end
+      info.func = function() DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption = DISEASE_BOTH;UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Diseases_DD,  DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption); end
       UIDropDownMenu_AddButton(info)
 
       info = {}
       info.text = DKROT_OPTIONS_CDR_DISEASES_DD_ONE
       info.value = DISEASE_ONE
-      info.func = function() DKROT_Settings.CD[Current_Spec].DiseaseOption = DISEASE_ONE;UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Diseases_DD,  DKROT_Settings.CD[Current_Spec].DiseaseOption); end
+      info.func = function() DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption = DISEASE_ONE;UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Diseases_DD,  DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption); end
       UIDropDownMenu_AddButton(info)
 
       info = {}
       info.text = DKROT_OPTIONS_CDR_DISEASES_DD_NONE
       info.value = DISEASE_NONE
-      info.func = function() DKROT_Settings.CD[Current_Spec].DiseaseOption = DISEASE_NONE;UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Diseases_DD,  DKROT_Settings.CD[Current_Spec].DiseaseOption); end
+      info.func = function() DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption = DISEASE_NONE;UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Diseases_DD,  DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption); end
       UIDropDownMenu_AddButton(info)
    end
 
@@ -3220,8 +2534,8 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          info.text = spell .. ((buff and " (Buff)") or "")
          info.value = spell .. ((buff and " (Buff)") or "")
          info.func = function()
-            DKROT_Settings.CD[Current_Spec][panel:GetName()][1] = spell
-            DKROT_Settings.CD[Current_Spec][panel:GetName()][2] = buff
+            DKROT_Settings.CD[DKROT.Current_Spec][panel:GetName()][1] = spell
+            DKROT_Settings.CD[DKROT.Current_Spec][panel:GetName()][2] = buff
             UIDropDownMenu_SetSelectedValue(panel, spell .. ((buff and " (Buff)") or ""))
             CloseDropDownMenus()
          end
@@ -3231,10 +2545,10 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       --Function to add specs specific CDs
       local function AddSpecCDs(Spec)
          for i = 1, #Spec do
-            if (Cooldowns.Buffs[Spec[i]] == nil or Cooldowns.Buffs[Spec[i]][2]) then
+            if (DKROT.Cooldowns.Buffs[Spec[i]] == nil or DKROT.Cooldowns.Buffs[Spec[i]][2]) then
                UIDropDownMenu_AddButton(DKROT_CDRPanel_DD_Item(self, Spec[i]), 2)
             end
-            if Cooldowns.Buffs[Spec[i]] ~= nil then
+            if DKROT.Cooldowns.Buffs[Spec[i]] ~= nil then
                UIDropDownMenu_AddButton(DKROT_CDRPanel_DD_Item(self, Spec[i], true), 2)
             end
          end
@@ -3283,26 +2597,26 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          local key = UIDROPDOWNMENU_MENU_VALUE["Level1_Key"]
 
          if key == "Spec" then
-            if (Current_Spec == SPEC_UNHOLY) then
-               AddSpecCDs(Cooldowns.UnholyCDs)
-            elseif (Current_Spec == SPEC_FROST) then
-               AddSpecCDs(Cooldowns.FrostCDs)
-            elseif (Current_Spec == SPEC_BLOOD) then
-               AddSpecCDs(Cooldowns.BloodCDs)
+            if (DKROT.Current_Spec == DKROT.SPECS.UNHOLY) then
+               AddSpecCDs(DKROT.Cooldowns.UnholyCDs)
+            elseif (DKROT.Current_Spec == DKROT.SPECS.FROST) then
+               AddSpecCDs(DKROT.Cooldowns.FrostCDs)
+            elseif (DKROT.Current_Spec == DKROT.SPECS.BLOOD) then
+               AddSpecCDs(DKROT.Cooldowns.BloodCDs)
             end
 
          elseif key == "Normal" then
-            AddSpecCDs(Cooldowns.NormCDs)
+            AddSpecCDs(DKROT.Cooldowns.NormCDs)
 
          elseif key == "Moves" then
-            for i = 1, #Cooldowns.Moves do
-               if GetSpellTexture(Cooldowns.Moves[i]) ~= nil then
-                  UIDropDownMenu_AddButton(DKROT_CDRPanel_DD_Item(self, Cooldowns.Moves[i]), 2)
+            for i = 1, #DKROT.Cooldowns.Moves do
+               if GetSpellTexture(DKROT.Cooldowns.Moves[i]) ~= nil then
+                  UIDropDownMenu_AddButton(DKROT_CDRPanel_DD_Item(self, DKROT.Cooldowns.Moves[i]), 2)
                end
             end
 
          elseif key == "Talents" then
-            AddSpecCDs(Cooldowns.TalentCDs)
+            AddSpecCDs(DKROT.Cooldowns.TalentCDs)
 
          elseif key == "Trinkets" then
             UIDropDownMenu_AddButton(DKROT_CDRPanel_DD_Item(self, DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1), 2)

--- a/core.lua
+++ b/core.lua
@@ -1,15 +1,14 @@
-local debugg = false
 if select(2, UnitClass("player")) == "DEATHKNIGHT" then
-   if debugg then print("DKROT:Starting")end
    local _, DKROT = ...
+   DKROT:Debug("Starting")
 
-   -----Create Main Frame-----
+   -- --- Create Main Frame-- ---
    DKROT.MainFrame = CreateFrame("Button", "DKROT", UIParent)
    DKROT.MainFrame:SetWidth(94)
    DKROT.MainFrame:SetHeight(68)
    DKROT.MainFrame:SetFrameStrata("BACKGROUND")
 
-   -----Locals-----
+   -- --- Locals-- ---
    -- Constants
    local PLAYER_NAME, PLAYER_RACE, PLAYER_PRESENCE = UnitName("player"), select(2, UnitRace("player")), 0
    local BBUUFF, BBFFUU, UUBBFF, UUFFBB, FFUUBB, FFBBUU = 1, 2, 3, 4, 5, 6
@@ -18,7 +17,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    local PRESENCE_BLOOD, PRESENCE_FROST, PRESENCE_UNHOLY = 1, 2, 3
    local IS_BUFF = 2
    local ITEM_LOAD_THRESHOLD = .5
-   local RUNE_COLOUR = {{1, 0, 0},{0, 0.95, 0},{0, 1, 1},{0.8, 0.1, 1}} --Blood,  Unholy,  Frost,  Death
+   local RUNE_COLOUR = {{1, 0, 0},{0, 0.95, 0},{0, 1, 1},{0.8, 0.1, 1}} -- Blood,  Unholy,  Frost,  Death
    local RuneTexture = {
       "Interface\\PlayerFrame\\UI-PlayerFrame-Deathknight-Blood",
       "Interface\\PlayerFrame\\UI-PlayerFrame-Deathknight-Unholy",
@@ -26,7 +25,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       "Interface\\PlayerFrame\\UI-PlayerFrame-Deathknight-Death",
    }
 
-   --Variables
+   -- Variables
    local loaded, mutex = false, false
    local mousex, mousey
    local font = 'Interface\\AddOns\\DKRot\\Font.ttf'
@@ -37,9 +36,9 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    local GCD, curtime, launchtime = 0, 0, 0
    local updatetimer = 0
 
-   if debugg then print("DKROT:Locals Done")end
+   DKROT:Debug("Locals Done")
 
-   --If User has Button Facade, then set up skinning function
+   -- If User has Button Facade, then set up skinning function
    local LBF = LibStub("LibButtonFacade", true)
    local MSQ = LibStub("Masque", true)
    if LBF or MSQ then
@@ -55,93 +54,94 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if DKROT.spells ~= nil then wipe(DKROT.spells) end
       DKROT.spells = {}
       DKROT.spells = {
-         ["Anti-Magic Shell"] = GetSpellInfo(48707), --lvl68
-         ["Army of the Dead"] = GetSpellInfo(42650), --lvl80
-         ["Blood Boil"] = GetSpellInfo(50842), --lvl56
+         ["Anti-Magic Shell"] = GetSpellInfo(48707), -- lvl68
+         ["Army of the Dead"] = GetSpellInfo(42650), -- lvl80
+         ["Blood Boil"] = GetSpellInfo(50842), -- lvl56
          ["Blood Plague"] = GetSpellInfo(55078),
-         ["Dark Simulacrum"] = GetSpellInfo(77606), --lvl85, Cata
-         ["Death and Decay"] = GetSpellInfo(43265), --lvl60
+         ["Dark Simulacrum"] = GetSpellInfo(77606), -- lvl85, Cata
+         ["Death and Decay"] = GetSpellInfo(43265), -- lvl60
          ["Death Coil"] = GetSpellInfo(47541),
          ["Death Grip"] = GetSpellInfo(49576),
-         ["Death Strike"] = GetSpellInfo(49998),  --lvl56
-         ["Empower Rune Weapon"] = GetSpellInfo(47568), --lvl76
+         ["Death Strike"] = GetSpellInfo(49998),  -- lvl56
+         ["Empower Rune Weapon"] = GetSpellInfo(47568), -- lvl76
          ["Frost Fever"] = GetSpellInfo(55095),
          ["Horn of Winter"] = GetSpellInfo(57330),
-         ["Icebound Fortitude"] = GetSpellInfo(48792), --lvl62
+         ["Icebound Fortitude"] = GetSpellInfo(48792), -- lvl62
          ["Icy Touch"] = GetSpellInfo(45477),
-         ["Mind Freeze"] = GetSpellInfo(47528), --lvl57
-         ["Outbreak"] = GetSpellInfo(77575), --lvl81, Cata
+         ["Mind Freeze"] = GetSpellInfo(47528), -- lvl57
+         ["Outbreak"] = GetSpellInfo(77575), -- lvl81, Cata
          ["Plague Strike"] = GetSpellInfo(45462),
-         ["Raise Ally"] = GetSpellInfo(61999), --lvl72
-         ["Raise Dead"] = GetSpellInfo(46584), --lvl56
-         ["Soul Reaper"] = GetSpellInfo(114866), --lvl87, MoP
-         ["Strangulate"] = GetSpellInfo(47476), --lvl58
+         ["Raise Ally"] = GetSpellInfo(61999), -- lvl72
+         ["Raise Dead"] = GetSpellInfo(46584), -- lvl56
+         ["Soul Reaper"] = GetSpellInfo(114866), -- lvl87, MoP
+         ["Strangulate"] = GetSpellInfo(47476), -- lvl58
          ["Unholy Strength"] = GetSpellInfo(53365),
 
-         --Talents
-         ["Anti-Magic Zone"] = GetSpellInfo(51052), --lvl57
-         ["Asphyxiate"] = GetSpellInfo(108194), --lvl58, MoP
-         ["Blood Charge"] = GetSpellInfo(114851), --lvl75
-         ["Blood Tap"] = GetSpellInfo(45529), --lvl75
-         ["Breath of Sindragosa"] = GetSpellInfo(152279), --lvl100, WoD
-         ["Chilblains"] = GetSpellInfo(50041), --lvl58
-         ["Conversion"] = GetSpellInfo(119975), --lvl60, MoP
-         ["Death Pact"] = GetSpellInfo(48743), --lvl60
-         ["Death Siphon"] = GetSpellInfo(108196), --lvl60, MoP
-         ["Death's Advance"] = GetSpellInfo(96268), --lvl58, MoP
-         ["Defile"] = GetSpellInfo(152280), --lvl100, WoD
-         ["Desecrated Ground"] = GetSpellInfo(108201), --lvl90, MoP
-         ["Gorefiend's Grasp"] = GetSpellInfo(108199), --lvl90, MoP
-         ["Lichborne"] = GetSpellInfo(49039), --lvl57
-         ["Necrotic Plague"] = GetSpellInfo(152281), --lvl100, WoD
-         ["Plague Leech"] = GetSpellInfo(123693), --lvl56, MoP
-         ["Remorseless Winter"] = GetSpellInfo(108200), --lvl90, MoP
-         ["Runic Corruption"] = GetSpellInfo(51460), --lvl75
-         ["Unholy Blight"] = GetSpellInfo(115989), --lvl56, MoP
+         -- Talents
+         ["Anti-Magic Zone"] = GetSpellInfo(51052), -- lvl57
+         ["Asphyxiate"] = GetSpellInfo(108194), -- lvl58, MoP
+         ["Blood Charge"] = GetSpellInfo(114851), -- lvl75
+         ["Blood Tap"] = GetSpellInfo(45529), -- lvl75
+         ["Breath of Sindragosa"] = GetSpellInfo(152279), -- lvl100, WoD
+         ["Chilblains"] = GetSpellInfo(50041), -- lvl58
+         ["Conversion"] = GetSpellInfo(119975), -- lvl60, MoP
+         ["Death Pact"] = GetSpellInfo(48743), -- lvl60
+         ["Death Siphon"] = GetSpellInfo(108196), -- lvl60, MoP
+         ["Death's Advance"] = GetSpellInfo(96268), -- lvl58, MoP
+         ["Defile"] = GetSpellInfo(152280), -- lvl100, WoD
+         ["Desecrated Ground"] = GetSpellInfo(108201), -- lvl90, MoP
+         ["Gorefiend's Grasp"] = GetSpellInfo(108199), -- lvl90, MoP
+         ["Lichborne"] = GetSpellInfo(49039), -- lvl57
+         ["Necrotic Plague"] = GetSpellInfo(152281), -- lvl100, WoD
+         ["Plague Leech"] = GetSpellInfo(123693), -- lvl56, MoP
+         ["Remorseless Winter"] = GetSpellInfo(108200), -- lvl90, MoP
+         ["Runic Corruption"] = GetSpellInfo(51460), -- lvl75
+         ["Unholy Blight"] = GetSpellInfo(115989), -- lvl56, MoP
 
-         --Blood Only
+         -- Blood Only
          ["Blood Shield"] = GetSpellInfo(77535),
-         ["Bone Shield"] = GetSpellInfo(49222), --lvl78
-         ["Crimson Scourge"] = GetSpellInfo(81136), --lvl84
-         ["Dancing Rune Weapon"] = GetSpellInfo(49028), --lvl74
-         ["Dark Command"] = GetSpellInfo(56222), --lvl58
-         ["Rune Tap"] = GetSpellInfo(48982), --lvl64
-         ["Scent of Blood"] = GetSpellInfo(49509), --lvl62, MoP
-         ["Vampiric Blood"] = GetSpellInfo(55233), --lvl76
-         ["Will of the Necropolis"] = GetSpellInfo(81164), --lvl70
+         ["Bone Shield"] = GetSpellInfo(49222), -- lvl78
+         ["Crimson Scourge"] = GetSpellInfo(81136), -- lvl84
+         ["Dancing Rune Weapon"] = GetSpellInfo(49028), -- lvl74
+         ["Dark Command"] = GetSpellInfo(56222), -- lvl58
+         ["Rune Tap"] = GetSpellInfo(48982), -- lvl64
+         ["Scent of Blood"] = GetSpellInfo(49509), -- lvl62, MoP
+         ["Vampiric Blood"] = GetSpellInfo(55233), -- lvl76
+         ["Will of the Necropolis"] = GetSpellInfo(81164), -- lvl70
 
-         --Frost Only
-         ["Freezing Fog"] = GetSpellInfo(59052), --lvl70
+         -- Frost Only
+         ["Freezing Fog"] = GetSpellInfo(59052), -- lvl70
          ["Frost Strike"] = GetSpellInfo(49143),
          ["Howling Blast"] = GetSpellInfo(49184),
-         ["Killing Machine"] = GetSpellInfo(51124), --lvl63
-         ["Obliterate"] = GetSpellInfo(49020), --lvl58
-         ["Pillar of Frost"] = GetSpellInfo(51271), --lvl68
+         ["Killing Machine"] = GetSpellInfo(51124), -- lvl63
+         ["Obliterate"] = GetSpellInfo(49020), -- lvl58
+         ["Pillar of Frost"] = GetSpellInfo(51271), -- lvl68
 
-         --Unholy Only
-         ["Dark Transformation"] = GetSpellInfo(63560), --lvl70
-         ["Festering Strike"] = GetSpellInfo(85948), --lvl62, Cata
+         -- Unholy Only
+         ["Dark Transformation"] = GetSpellInfo(63560), -- lvl70
+         ["Enhanced Dark Transformation"] = GetSpellInfo(157412), -- lvl92/100, WoD (random)
+         ["Festering Strike"] = GetSpellInfo(85948), -- lvl62, Cata
          ["Gnaw"] =  GetSpellInfo(91800),
-         ["Improved Soul Reaper"] = GetSpellInfo(157342), --lvl92/100, WoD (random)
-         ["Scourge Strike"] = GetSpellInfo(55090), --lvl58
-         ["Shadow Infusion"] = GetSpellInfo(91342), --lvl60
-         ["Sudden Doom"] = GetSpellInfo(81340), --lvl64
-         ["Summon Gargoyle"] = GetSpellInfo(49206), --lvl74
+         ["Improved Soul Reaper"] = GetSpellInfo(157342), -- lvl92/100, WoD (random)
+         ["Scourge Strike"] = GetSpellInfo(55090), -- lvl58
+         ["Shadow Infusion"] = GetSpellInfo(91342), -- lvl60
+         ["Sudden Doom"] = GetSpellInfo(81340), -- lvl64
+         ["Summon Gargoyle"] = GetSpellInfo(49206), -- lvl74
 
-         --Racials
-         ["Human"] = GetSpellInfo(59752),--Every Man for Himself
-         ["Dwarf"] = GetSpellInfo(20594),--Stoneform
-         ["NightElf"] = GetSpellInfo(58984),--Shadowmeld
-         ["Gnome"] = GetSpellInfo(20589),--Escape Artist
-         ["Draenei"] = GetSpellInfo(28880),--Gift of the Naaru
-         ["Worgen"] = GetSpellInfo(68992),--Darkflight
+         -- Racials
+         ["Human"] = GetSpellInfo(59752),-- Every Man for Himself
+         ["Dwarf"] = GetSpellInfo(20594),-- Stoneform
+         ["NightElf"] = GetSpellInfo(58984),-- Shadowmeld
+         ["Gnome"] = GetSpellInfo(20589),-- Escape Artist
+         ["Draenei"] = GetSpellInfo(28880),-- Gift of the Naaru
+         ["Worgen"] = GetSpellInfo(68992),-- Darkflight
 
-         ["Orc"] = GetSpellInfo(33697),--Blood Fury
-         ["Scourge"] = GetSpellInfo(7744),--Will of the Forsaken
-         ["Tauren"] = GetSpellInfo(20549),--War Stomp
-         ["Troll"] = GetSpellInfo(26297),--Berserking
-         ["BloodElf"] = GetSpellInfo(28730),--Arcane Torrent
-         ["Goblin"] = GetSpellInfo(69070),--Rocket Jump
+         ["Orc"] = GetSpellInfo(33697),-- Blood Fury
+         ["Scourge"] = GetSpellInfo(7744),-- Will of the Forsaken
+         ["Tauren"] = GetSpellInfo(20549),-- War Stomp
+         ["Troll"] = GetSpellInfo(26297),-- Berserking
+         ["BloodElf"] = GetSpellInfo(28730),-- Arcane Torrent
+         ["Goblin"] = GetSpellInfo(69070),-- Rocket Jump
       }
       DKROT.DTspells = { -- ID, Duration, Effected by talent
          [DKROT.spells["Frost Fever"]] = {55095, 30},
@@ -151,14 +151,14 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          [DKROT.spells["Necrotic Plague"]] = {152281, 30},
          [DKROT.spells["Chilblains"]] = {50435, 10},
       }
-      if debugg then print("DKROT:Spells Loaded")end
+      DKROT:Debug("Spells Loaded")
    end
 
    function DKROT:LoadCooldowns()
       if DKROT.Cooldowns~= nil then wipe(DKROT.Cooldowns) end
       DKROT.Cooldowns = {}
       DKROT.Cooldowns = {
-         NormCDs = {--CDs that all DKs get
+         NormCDs = {-- CDs that all DKs get
             DKROT.spells["Anti-Magic Shell"],
             DKROT.spells["Army of the Dead"],
             DKROT.spells["Blood Charge"],
@@ -213,8 +213,8 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             DKROT.spells["Sudden Doom"],
             DKROT.spells["Summon Gargoyle"],
          },
-         Buffs = {--List of Buffs {Who gets buff?, Is it also a CD?}
-            --normal
+         Buffs = {-- List of Buffs {Who gets buff?, Is it also a CD?}
+            -- normal
             [DKROT.spells["Anti-Magic Shell"]] = {"player", true},
             [DKROT.spells["Asphyxiate"]] = {"target", true},
             [DKROT.spells["Blood Charge"]] = {"player", false},
@@ -233,7 +233,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             [DKROT.spells["Unholy Blight"]] = {"player", true},
             [DKROT.spells["Unholy Strength"]] = {"player", false},
 
-            --blood
+            -- blood
             [DKROT.spells["Blood Shield"]] = {"player", false},
             [DKROT.spells["Bone Shield"]] = {"player", true},
             [DKROT.spells["Crimson Scourge"]] = {"player", false},
@@ -242,17 +242,17 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             [DKROT.spells["Vampiric Blood"]] = {"player", true},
             [DKROT.spells["Will of the Necropolis"]] = {"player", false},
 
-            --frost
+            -- frost
             [DKROT.spells["Pillar of Frost"]] = {"player", true},
             [DKROT.spells["Freezing Fog"]] = {"player", false},
             [DKROT.spells["Killing Machine"]] = {"player", false},
 
-            --unholy
+            -- unholy
             [DKROT.spells["Dark Transformation"]] = {"pet", false},
             [DKROT.spells["Shadow Infusion"]] = {"pet", false},
             [DKROT.spells["Sudden Doom"]] = {"player", false},
          },
-         Moves = {--List of Moves that can be watched when availible
+         Moves = {-- List of Moves that can be watched when availible
             DKROT.spells["Blood Boil"],
             DKROT.spells["Death Coil"],
             DKROT.spells["Death Siphon"],
@@ -267,223 +267,223 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             DKROT.spells["Soul Reaper"],
          },
       }
-      if debugg then print("DKROT:Cooldowns Loaded")end
+      DKROT:Debug("Cooldowns Loaded")
       return DKROT.Cooldowns
    end
 
    function DKROT:LoadTrinkets()
       local loaded = true
 
-      local function AddTrinket(name, info) --BuffID, Is on use?, (ItemID or ICD), start, cd flag, alternative buff
+      local function AddTrinket(name, info) -- BuffID, Is on use?, (ItemID or ICD), start, cd flag, alternative buff
          if name == nil then
             loaded = false
-            if debugg then print("DKROT:Trinket Not Found - Buff: "..info[1])end
+            DKROT:Debug("Trinket Not Found - Buff: " .. info[1])
          else
             DKROT.Cooldowns.Trinkets[name] = info
          end
       end
       DKROT.Cooldowns.Trinkets = {}
 
-      --Test trinket that doesn't exist
-      --AddTrinket(select(1, GetItemInfo(1)), {"Test Trinket"})
+      -- Test trinket that doesn't exist
+      -- AddTrinket(select(1, GetItemInfo(1)), {"Test Trinket"})
 
-      --On-Use
-      --Impatience of Youth
+      -- On-Use
+      -- Impatience of Youth
       DKROT.spells["Thrill of Victory"] = GetSpellInfo(91828)
       AddTrinket(select(1, GetItemInfo(62469)), {DKROT.spells["Thrill of Victory"], true, 62469})
 
-      --Vial of Stolen Memories
+      -- Vial of Stolen Memories
       DKROT.spells["Memory of Invincibility"] = GetSpellInfo(92213)
       AddTrinket(select(1, GetItemInfo(59515)), {DKROT.spells["Memory of Invincibility"], true, 59515})
 
-      --Figurine - King of Boars
+      -- Figurine - King of Boars
       DKROT.spells["King of Boars"] = GetSpellInfo(73522)
       AddTrinket(select(1, GetItemInfo(52351)), {DKROT.spells["King of Boars"], true, 52351})
 
-      --Figurine - Earthen Guardian
+      -- Figurine - Earthen Guardian
       DKROT.spells["Earthen Guardian"] = GetSpellInfo(73550)
       AddTrinket(select(1, GetItemInfo(52352)), {DKROT.spells["Earthen Guardian"], true, 52352})
 
-      --Might of the Ocean
+      -- Might of the Ocean
       DKROT.spells["Typhoon"] = GetSpellInfo(91340)
       AddTrinket(select(1, GetItemInfo(56285)), {DKROT.spells["Typhoon"], true, 56285})
 
-      --Magnetite Mirror
+      -- Magnetite Mirror
       DKROT.spells["Polarization"] = GetSpellInfo(91351)
       AddTrinket(select(1, GetItemInfo(55814)), {DKROT.spells["Polarization"], true, 55814})
 
-      --Mirror of Broken Images
+      -- Mirror of Broken Images
       DKROT.spells["Image of Immortality"] = GetSpellInfo(92222)
       AddTrinket(select(1, GetItemInfo(62466)), {DKROT.spells["Image of Immortality"], true, 62466})
 
-      --Essence of the Eternal Flame
+      -- Essence of the Eternal Flame
       DKROT.spells["Essence of the Eternal Flame"] = GetSpellInfo(97010)
       AddTrinket(select(1, GetItemInfo(69002)), {DKROT.spells["Essence of the Eternal Flame"], true, 69002})
 
-      --Moonwell Phial
+      -- Moonwell Phial
       DKROT.spells["Summon Splashing Waters"] = GetSpellInfo(101492)
       AddTrinket(select(1, GetItemInfo(70143)), {DKROT.spells["Summon Splashing Waters"], true, 70143})
 
-      --Scales of Life
+      -- Scales of Life
       DKROT.spells["Weight of a Feather"] = GetSpellInfo(97117)
       AddTrinket(select(1, GetItemInfo(69109)), {DKROT.spells["Weight of a Feather"], true, 69109})
 
-      --Fire of the Deep
+      -- Fire of the Deep
       DKROT.spells["Elusive"] = GetSpellInfo(109779)
       AddTrinket(select(1, GetItemInfo(78008)), {DKROT.spells["Elusive"], true, 78008})
 
-      --Rotting Skull
+      -- Rotting Skull
       DKROT.spells["Titanic Strength"] = GetSpellInfo(109746)
       AddTrinket(select(1, GetItemInfo(77116)), {DKROT.spells["Titanic Strength"], true, 77116})
 
-      --Soul Barrier
+      -- Soul Barrier
       DKROT.spells["Soul Barrier"] = GetSpellInfo(138979)
       AddTrinket(select(1, GetItemInfo(94528)), {DKROT.spells["Soul Barrier"], true, 94528})
 
-      --Badge of Victory
+      -- Badge of Victory
       DKROT.spells["Call of Victory"] = GetSpellInfo(92224)
-      AddTrinket(select(1, GetItemInfo(64689)), {DKROT.spells["Call of Victory"], true, 64689})--Bloodthirsty Gladiator's
-      AddTrinket(select(1, GetItemInfo(61034)), {DKROT.spells["Call of Victory"], true, 61034})--Vicious Gladiator's s9
-      AddTrinket(select(1, GetItemInfo(70519)), {DKROT.spells["Call of Victory"], true, 70519})--Vicious Gladiator's s10
-      AddTrinket(select(1, GetItemInfo(70400)), {DKROT.spells["Call of Victory"], true, 70400})--Ruthless Gladiator's s10
-      AddTrinket(select(1, GetItemInfo(72450)), {DKROT.spells["Call of Victory"], true, 72450})--Ruthless Gladiator's s11
-      AddTrinket(select(1, GetItemInfo(73496)), {DKROT.spells["Call of Victory"], true, 73496})--Cataclysmic Gladiator's s11
-      AddTrinket(select(1, GetItemInfo(91410)), {DKROT.spells["Call of Victory"], true, 126679})--Tyrannical Gladiator's s13
-      AddTrinket(select(1, GetItemInfo(94349)), {DKROT.spells["Call of Victory"], true, 126679})--Tyrannical Gladiator's s13
+      AddTrinket(select(1, GetItemInfo(64689)), {DKROT.spells["Call of Victory"], true, 64689})-- Bloodthirsty Gladiator's
+      AddTrinket(select(1, GetItemInfo(61034)), {DKROT.spells["Call of Victory"], true, 61034})-- Vicious Gladiator's s9
+      AddTrinket(select(1, GetItemInfo(70519)), {DKROT.spells["Call of Victory"], true, 70519})-- Vicious Gladiator's s10
+      AddTrinket(select(1, GetItemInfo(70400)), {DKROT.spells["Call of Victory"], true, 70400})-- Ruthless Gladiator's s10
+      AddTrinket(select(1, GetItemInfo(72450)), {DKROT.spells["Call of Victory"], true, 72450})-- Ruthless Gladiator's s11
+      AddTrinket(select(1, GetItemInfo(73496)), {DKROT.spells["Call of Victory"], true, 73496})-- Cataclysmic Gladiator's s11
+      AddTrinket(select(1, GetItemInfo(91410)), {DKROT.spells["Call of Victory"], true, 126679})-- Tyrannical Gladiator's s13
+      AddTrinket(select(1, GetItemInfo(94349)), {DKROT.spells["Call of Victory"], true, 126679})-- Tyrannical Gladiator's s13
 
-      --PvP Trinkets
+      -- PvP Trinkets
       DKROT.spells["PvP Trinket"] = GetSpellInfo(42292)
-      AddTrinket(select(1, GetItemInfo(64794)), {DKROT.spells["PvP Trinket"], true, 64794})--Bloodthirsty
-      AddTrinket(select(1, GetItemInfo(60807)), {DKROT.spells["PvP Trinket"], true, 60807})--Vicious s9
-      AddTrinket(select(1, GetItemInfo(70607)), {DKROT.spells["PvP Trinket"], true, 70607})--Vicious s10
-      AddTrinket(select(1, GetItemInfo(70395)), {DKROT.spells["PvP Trinket"], true, 70395})--Ruthless s10
-      AddTrinket(select(1, GetItemInfo(72413)), {DKROT.spells["PvP Trinket"], true, 72413})--Ruthless s11
-      AddTrinket(select(1, GetItemInfo(73537)), {DKROT.spells["PvP Trinket"], true, 73537})--Cataclysmic s11
+      AddTrinket(select(1, GetItemInfo(64794)), {DKROT.spells["PvP Trinket"], true, 64794})-- Bloodthirsty
+      AddTrinket(select(1, GetItemInfo(60807)), {DKROT.spells["PvP Trinket"], true, 60807})-- Vicious s9
+      AddTrinket(select(1, GetItemInfo(70607)), {DKROT.spells["PvP Trinket"], true, 70607})-- Vicious s10
+      AddTrinket(select(1, GetItemInfo(70395)), {DKROT.spells["PvP Trinket"], true, 70395})-- Ruthless s10
+      AddTrinket(select(1, GetItemInfo(72413)), {DKROT.spells["PvP Trinket"], true, 72413})-- Ruthless s11
+      AddTrinket(select(1, GetItemInfo(73537)), {DKROT.spells["PvP Trinket"], true, 73537})-- Cataclysmic s11
 
-      AddTrinket(select(1, GetItemInfo(91329)), {DKROT.spells["PvP Trinket"], true, 91329})--Tyrannical s13
+      AddTrinket(select(1, GetItemInfo(91329)), {DKROT.spells["PvP Trinket"], true, 91329})-- Tyrannical s13
       AddTrinket(select(1, GetItemInfo(91330)), {DKROT.spells["PvP Trinket"], true, 91330})
       AddTrinket(select(1, GetItemInfo(91331)), {DKROT.spells["PvP Trinket"], true, 91331})
       AddTrinket(select(1, GetItemInfo(91332)), {DKROT.spells["PvP Trinket"], true, 91332})
 
-      AddTrinket(select(1, GetItemInfo(91683)), {DKROT.spells["PvP Trinket"], true, 91683})--Malev s13
+      AddTrinket(select(1, GetItemInfo(91683)), {DKROT.spells["PvP Trinket"], true, 91683})-- Malev s13
 
       AddTrinket(select(1, GetItemInfo(51378)), {DKROT.spells["PvP Trinket"], true, 51378})
       AddTrinket(select(1, GetItemInfo(51377)), {DKROT.spells["PvP Trinket"], true, 51377})
 
-      --Stacking Buff
-      --License to Slay
+      -- Stacking Buff
+      -- License to Slay
       DKROT.spells["Slayer"] = GetSpellInfo(91810)
       AddTrinket(select(1, GetItemInfo(58180)), {DKROT.spells["Slayer"], false, 0, 0, false})
 
-      --Fury of Angerforge
+      -- Fury of Angerforge
       DKROT.spells["Forged Fury"] = GetSpellInfo(91836)
       DKROT.spells["Raw Fury"] = GetSpellInfo(91832)
       AddTrinket(select(1, GetItemInfo(59461)), {DKROT.spells["Forged Fury"], false, 120, 0, false, DKROT.spells["Raw Fury"]})
 
-      --Apparatus of Khaz'goroth
+      -- Apparatus of Khaz'goroth
       DKROT.spells["Titanic Power"] = GetSpellInfo(96923)
       DKROT.spells["Blessing of Khaz'goroth"] = GetSpellInfo(97127)
       AddTrinket(select(1, GetItemInfo(69113)), {DKROT.spells["Blessing of Khaz'goroth"], false, 120, 0, false, DKROT.spells["Titanic Power"]})
 
-      --Vessel of Acceleration
+      -- Vessel of Acceleration
       DKROT.spells["Accelerated"] = GetSpellInfo(96980)
       AddTrinket(select(1, GetItemInfo(68995)), {DKROT.spells["Accelerated"], false, 0, 0, false})
 
-      --Eye of Unmaking
+      -- Eye of Unmaking
       DKROT.spells["Titanic Strength"] = GetSpellInfo(107966)
       AddTrinket(select(1, GetItemInfo(77200)), {DKROT.spells["Titanic Strength"], false, 0, 0, false})
 
-      --Resolve of Undying
+      -- Resolve of Undying
       DKROT.spells["Preternatural Evasion"] = GetSpellInfo(109782)
       AddTrinket(select(1, GetItemInfo(77998)), {DKROT.spells["Preternatural Evasion"], false, 0, 0, false})
 
-      --Spark of Zandalar
+      -- Spark of Zandalar
       DKROT.spells["Spark of Zandalar"] = GetSpellInfo(138958)
       AddTrinket(select(1, GetItemInfo(94526)), {DKROT.spells["Spark of Zandalar"], false, 0, 0, false})
 
-      --Gaze of the Twins
+      -- Gaze of the Twins
       DKROT.spells["Eye of Brutality"] = GetSpellInfo(139170)
       AddTrinket(select(1, GetItemInfo(94529)), {DKROT.spells["Eye of Brutality"], false, 0, 0, false})
 
-      --ICD
-      --Heart of Rage
+      -- ICD
+      -- Heart of Rage
       DKROT.spells["Rageheart"] = GetSpellInfo(92345)
       AddTrinket(select(1, GetItemInfo(65072)), {DKROT.spells["Rageheart"], false, 20*5, 0, false})
 
-      --Heart of Solace
+      -- Heart of Solace
       DKROT.spells["Heartened"] = GetSpellInfo(91363)
       AddTrinket(select(1, GetItemInfo(55868)), {DKROT.spells["Heartened"], false, 20*5, 0, false})
 
-      --Crushing Weight
+      -- Crushing Weight
       DKROT.spells["Race Against Death"] = GetSpellInfo(92342)
       AddTrinket(select(1, GetItemInfo(59506)), {DKROT.spells["Race Against Death"], false, 15*5, 0, false})
 
-      --Symbiotic Worm
+      -- Symbiotic Worm
       DKROT.spells["Turn of the Worm"] = GetSpellInfo(92235)
       AddTrinket(select(1, GetItemInfo(59332)), {DKROT.spells["Turn of the Worm"], false, 30, 0, false})
 
-      --Bedrock Talisman
+      -- Bedrock Talisman
       DKROT.spells["Tectonic Shift"] = GetSpellInfo(92233)
       AddTrinket(select(1, GetItemInfo(58182)), {DKROT.spells["Tectonic Shift"], false, 30, 0, false})
 
-      --Porcelain Crab
+      -- Porcelain Crab
       DKROT.spells["Hardened Shell"] = GetSpellInfo(92174)
       AddTrinket(select(1, GetItemInfo(56280)), {DKROT.spells["Hardened Shell"], false, 20*5, 0, false})
 
-      --Right Eye of Rajh
+      -- Right Eye of Rajh
       DKROT.spells["Eye of Doom"] = GetSpellInfo(91368)
       AddTrinket(select(1, GetItemInfo(56431)), {DKROT.spells["Eye of Doom"], false, 10*5, 0, false})
 
-      --Rosary of Light
+      -- Rosary of Light
       DKROT.spells["Rosary of Light"] = GetSpellInfo(102660)
       AddTrinket(select(1, GetItemInfo(72901)), {DKROT.spells["Rosary of Light"], false, 20*5, 0, false})
 
-      --Creche of the Final Dragon
+      -- Creche of the Final Dragon
       DKROT.spells["Find Weakness"] = GetSpellInfo(109744)
       AddTrinket(select(1, GetItemInfo(77992)), {DKROT.spells["Find Weakness"], false, 20*5, 0, false})
 
-      --Indomitable Pride
+      -- Indomitable Pride
       DKROT.spells["Indomitable"] = GetSpellInfo(109786)
       AddTrinket(select(1, GetItemInfo(78003)), {DKROT.spells["Indomitable"], false, 60, 0, false})
 
-      --Soulshifter Vortex
+      -- Soulshifter Vortex
       DKROT.spells["Haste"] = GetSpellInfo(109777)
       AddTrinket(select(1, GetItemInfo(77990)), {DKROT.spells["Haste"], false, 20*5, 0, false})
 
-      --Veil of Lies
+      -- Veil of Lies
       DKROT.spells["Veil of Lies"] = GetSpellInfo(102666)
       AddTrinket(select(1, GetItemInfo(72900)), {DKROT.spells["Veil of Lies"], false, 20*5, 0, false})
 
-      --Spidersilk Spindle
+      -- Spidersilk Spindle
       DKROT.spells["Loom of Fate"] = GetSpellInfo(97130)
       AddTrinket(select(1, GetItemInfo(69138)), {DKROT.spells["Loom of Fate"], false, 60, 0, false})
 
-      --Master Pit Fighter
+      -- Master Pit Fighter
       DKROT.spells["Master Pit Fighter"] = GetSpellInfo(109996)
       AddTrinket(select(1, GetItemInfo(74035)), {DKROT.spells["Master Pit Fighter"], false, 20*5, 0, false})
 
-       --Varo'then's Brooch
+       -- Varo'then's Brooch
        DKROT.spells["Varo'then's Brooch"] = GetSpellInfo(102664)
        AddTrinket(select(1, GetItemInfo(72899)), {DKROT.spells["Varo'then's Brooch"], false, 20*5, 0, false})
 
-      --Luckydo Coin
+      -- Luckydo Coin
       DKROT.spells["Luckydo Coin"] = GetSpellInfo(120175)
       AddTrinket(select(1, GetItemInfo(82578)), {DKROT.spells["Luckydo Coin"], false, 20*5, 0, false})
 
-      --Brutal Talisman of the Shado-Pan Assault
+      -- Brutal Talisman of the Shado-Pan Assault
       DKROT.spells["Surge of Strength"] = GetSpellInfo(138702)
       AddTrinket(select(1, GetItemInfo(94508)), {DKROT.spells["Surge of Strength"], false, 20*5, 0, false})
 
-      --Fabled Feather of Ji-Kun
+      -- Fabled Feather of Ji-Kun
       DKROT.spells["Feathers of Fury"] = GetSpellInfo(138759)
       AddTrinket(select(1, GetItemInfo(94515)), {DKROT.spells["Feathers of Fury"], false, 20*5, 0, false})
 
-      if debugg then print("DKROT:Trinkets Loaded")end
+      DKROT:Debug("Trinkets Loaded")
       return loaded
    end
 
-   --In: timeleft - seconds
-   --Out: formated string of hours, minutes and seconds
+   -- In: timeleft - seconds
+   -- Out: formated string of hours, minutes and seconds
    local function formatTime(timeleft)
       if timeleft > 3600 then
          return format("%dh:%dm", timeleft/3600, ((timeleft%3600)/60))
@@ -495,8 +495,8 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       return timeleft
    end
 
-   --In: start- when the spell cd started  dur- duration of the cd
-   --Out: returns if the spell is or will be off cd in the next GCD
+   -- In: start- when the spell cd started  dur- duration of the cd
+   -- Out: returns if the spell is or will be off cd in the next GCD
    function DKROT:isOffCD(spell)
       local start, dur = GetSpellCooldown(spell)
       return (dur + start - curtime - GCD <= 0)
@@ -507,8 +507,8 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       return cool or (dur + start - curtime - GCD <= 0)
    end
 
-   --In:tabl - table to check if key is in it  key- key you are looking for
-   --Out: returns true if key is in table
+   -- In:tabl - table to check if key is in it  key- key you are looking for
+   -- Out: returns true if key is in table
    local function inTable(tabl, key)
       for i = 1, #tabl do
          if tabl[i] == key then return true end
@@ -517,7 +517,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    end
 
    local resize = nil
-   --Sets up required information for each element that can be moved
+   -- Sets up required information for each element that can be moved
    function DKROT:SetupMoveFunction(frame)
       frame.Drag = CreateFrame("Button", "ResizeGrip", frame) -- Grip Buttons from Omen2
       frame.Drag:SetFrameLevel(frame:GetFrameLevel() + 100)
@@ -546,29 +546,24 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       frame:EnableMouse(false)
       frame:SetMovable(true)
 
-      --When mouse held, move
+      -- When mouse held, move
       frame:SetScript("OnMouseDown", function(self, button)
-         if debugg then print("DKROT:Mouse Down "..self:GetName())end
+         DKROT:Debug("Mouse Down " .. self:GetName())
          CloseDropDownMenus()
-      --   self.x1, self.y1 = select(4, self:GetPoint())
          self:StartMoving()
-      --   self.x2, self.y2 = select(4, self:GetPoint())
       end)
 
-      --When mouse released, save position
+      -- When mouse released, save position
       frame:SetScript("OnMouseUp", function(self, button)
-         if debugg then print("DKROT:Mouse Up "..self:GetName())end
-      --   self.x3, self.y3 = select(4, self:GetPoint())
-      --   print("Delta "..(self.x3-self.x2)+self.x1.." "..(self.y3-self.y2)+self.y1)
-      --   DKROT_Settings.Location[self:GetName()].X, DKROT_Settings.Location[self:GetName()].Y = (self.x3-self.x2)+self.x1, (self.y3-self.y2)+self.y1
+         DKROT:Debug("Mouse Up " .. self:GetName())
          self:StopMovingOrSizing()
          DKROT_Settings.Location[self:GetName()].Point, DKROT_Settings.Location[self:GetName()].Rel, DKROT_Settings.Location[self:GetName()].RelPoint, DKROT_Settings.Location[self:GetName()].X, DKROT_Settings.Location[self:GetName()].Y = self:GetPoint()
       end)
    end
 
-   --Icon template
-   --In: name: the name of the icon frame   parent: the icons parent   spellname: the spell the icon will first display   size:height and width in pixels
-   --Out: returns the icon create by parameters
+   -- Icon template
+   -- In: name: the name of the icon frame   parent: the icons parent   spellname: the spell the icon will first display   size:height and width in pixels
+   -- Out: returns the icon create by parameters
    function DKROT:CreateIcon(name, parent, spellname, size)
       frame = CreateFrame('Button', name, parent)
       frame:SetWidth(size)
@@ -607,7 +602,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT:SetupMoveFunction(DKROT.CD[i])
       end
 
-      --List of CD frame names, using the name of dropdown menu to allow easy saving and fetching
+      -- List of CD frame names, using the name of dropdown menu to allow easy saving and fetching
       CDDisplayList = {
          "DKROT_CDRPanel_DD_CD1_One",
          "DKROT_CDRPanel_DD_CD1_Two",
@@ -619,7 +614,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          "DKROT_CDRPanel_DD_CD4_Two",
       }
 
-      --Create the Icons with desired paramaters
+      -- Create the Icons with desired paramaters
       for i = 1, #CDDisplayList do
          DKROT.CD[CDDisplayList[i]] = DKROT:CreateIcon(CDDisplayList[i].."Butt", DKROT.MainFrame, DKROT.spells["Army of the Dead"], 32)
          DKROT.CD[CDDisplayList[i]].Time:SetFont(font, 11, "OUTLINE")
@@ -627,7 +622,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT.CD[CDDisplayList[i]]:EnableMouse(false)
       end
 
-      --Give Icons their position based on parent
+      -- Give Icons their position based on parent
       DKROT.CD[CDDisplayList[1]]:SetPoint("TOPLEFT", DKROT.CD[1], "TOPLEFT", 1, -1)
       DKROT.CD[CDDisplayList[2]]:SetPoint("TOPLEFT", DKROT.CD[CDDisplayList[1]], "BOTTOMLEFT", 0, -2)
       DKROT.CD[CDDisplayList[3]]:SetPoint("TOPRIGHT", DKROT.CD[2], "TOPRIGHT", -1, -1)
@@ -636,13 +631,13 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       DKROT.CD[CDDisplayList[6]]:SetPoint("TOPLEFT", DKROT.CD[CDDisplayList[5]], "BOTTOMLEFT", 0, -2)
       DKROT.CD[CDDisplayList[7]]:SetPoint("TOPRIGHT", DKROT.CD[4], "TOPRIGHT", -1, -1)
       DKROT.CD[CDDisplayList[8]]:SetPoint("TOPLEFT", DKROT.CD[CDDisplayList[7]], "BOTTOMLEFT", 0, -2)
-      if debugg then print("DKROT:Cooldowns Created")end
+      DKROT:Debug("Cooldowns Created")
    end
 
    function DKROT:CreateUI()
       DKROT:SetupMoveFunction(DKROT.MainFrame)
 
-      --Create Rune bar frame
+      -- Create Rune bar frame
       DKROT.RuneBar = CreateFrame("Button", "DKROT.RuneBar", DKROT.MainFrame)
       DKROT.RuneBar:SetHeight(23)
       DKROT.RuneBar:SetWidth(94)
@@ -692,7 +687,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
       DKROT:SetupMoveFunction(DKROT.RuneBarHolder)
 
-      --Create Runic Power frame
+      -- Create Runic Power frame
       DKROT.RunicPower = CreateFrame("Button", "DKROT.RunicPower", DKROT.MainFrame)
       DKROT.RunicPower:SetHeight(23)
       DKROT.RunicPower:SetWidth(47)
@@ -704,7 +699,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       DKROT.RunicPower.Text:SetFont(font, 18, "OUTLINE")
       DKROT:SetupMoveFunction(DKROT.RunicPower)
 
-      --Create frame for Diseases with 2 icons for their respective disease
+      -- Create frame for Diseases with 2 icons for their respective disease
       DKROT.Diseases = CreateFrame("Button", "DKROT.Diseases", DKROT.MainFrame)
       DKROT.Diseases:SetHeight(24)
       DKROT.Diseases:SetWidth(47)
@@ -721,13 +716,13 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       DKROT.Diseases.FF:SetBackdropColor(0, 0, 0, 0)
       DKROT:SetupMoveFunction(DKROT.Diseases)
 
-      --Create the Frame and Icon for the large main Priority Icon
+      -- Create the Frame and Icon for the large main Priority Icon
       DKROT.Move = DKROT:CreateIcon('DKROT.Move', DKROT.MainFrame, DKROT.spells["Death Coil"], 47)
       DKROT.Move.Time:SetFont(font, 16, "OUTLINE")
       DKROT.Move.Stack:SetFont(font, 15, "OUTLINE")
       DKROT:SetupMoveFunction(DKROT.Move)
 
-      --Create backdrop for move
+      -- Create backdrop for move
       DKROT.MoveBackdrop = CreateFrame('Frame', nil, DKROT.MainFrame)
       DKROT.MoveBackdrop:SetHeight(47)
       DKROT.MoveBackdrop:SetWidth(47)
@@ -736,14 +731,14 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       DKROT.MoveBackdrop:SetBackdropColor(0, 0, 0, 0.5)
       DKROT.MoveBackdrop:SetAllPoints(DKROT.Move)
 
-      --Mini AOE icon to be placed in the Priority Icon
+      -- Mini AOE icon to be placed in the Priority Icon
       DKROT.Move.AOE = DKROT:CreateIcon('DKROT.AOE', DKROT.Move, DKROT.spells["Death Coil"], 18)
       DKROT.Move.AOE:SetPoint("BOTTOMLEFT", DKROT.Move, "BOTTOMLEFT", 2, 2)
 
-      --Mini Interrupt icon to be placed in the Priority Icon
+      -- Mini Interrupt icon to be placed in the Priority Icon
       DKROT.Move.Interrupt = DKROT:CreateIcon('DKROT.Interrupt', DKROT.Move, DKROT.spells["Mind Freeze"], 18)
       DKROT.Move.Interrupt:SetPoint("TOPRIGHT", DKROT.Move, "TOPRIGHT", -2, -2)
-      if debugg then print("DKROT:UI Created")end
+      DKROT:Debug("UI Created")
 
       DKROT.DT = CreateFrame("Frame", "DKROT.DT", UIPARENT)
       DKROT.DT:SetHeight(5*25)
@@ -762,33 +757,33 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       BloodShieldTooltip:CreateFontString( "$parentTextRight1", nil, "GameTooltipText" ))
    end
 
-   ------Update Frames------
-   --In:location - name or location of the settings for specific CD   frame- frame in which to set the icon for
-   --Out:: N/A (does not return but does set icon settings
+   -- --- -Update Frames-- --- -
+   -- In:location - name or location of the settings for specific CD   frame- frame in which to set the icon for
+   -- Out:: N/A (does not return but does set icon settings
    function DKROT:UpdateCD(location, frame)
-      --Reset Icon
+      -- Reset Icon
       frame.Time:SetText("")
       frame.Stack:SetText("")
 
-      --If the option is not set to nothing
+      -- If the option is not set to nothing
       if DKROT_Settings.CD[DKROT.Current_Spec][location] ~= nil and DKROT_Settings.CD[DKROT.Current_Spec][location][1] ~= nil and
          DKROT_Settings.CD[DKROT.Current_Spec][location][1] ~= DKROT_OPTIONS_FRAME_VIEW_NONE then
          frame:SetAlpha(1)
          frame.Icon:SetVertexColor(1, 1, 1, 1)
-         if DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_PRIORITY then --Priority
-            --If targeting something that you can attack and is not dead
+         if DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_PRIORITY then -- Priority
+            -- If targeting something that you can attack and is not dead
             if (UnitCanAttack("player", "target") and (not UnitIsDead("target"))) then
-               --Get Icon from Priority Rotation
+               -- Get Icon from Priority Rotation
                frame.Icon:SetTexture(DKROT:GetNextMove(frame.Icon))
             else
                frame.Icon:SetTexture(nil)
             end
-         elseif DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_PRESENCE then --Presence
+         elseif DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_PRESENCE then -- Presence
             frame.Icon:SetTexture(nil)
             if PLAYER_PRESENCE > 0 then
                frame.Icon:SetTexture(select(1, GetShapeshiftFormInfo(PLAYER_PRESENCE)))
             end
-         elseif DKROT_Settings.CD[DKROT.Current_Spec][location][IS_BUFF] then --Buff/DeBuff
+         elseif DKROT_Settings.CD[DKROT.Current_Spec][location][IS_BUFF] then -- Buff/DeBuff
             local icon, count, dur, expirationTime
 
             if DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT.spells["Dark Simulacrum"] then
@@ -797,7 +792,12 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                   simtime = curtime
                   for i = 1, 120 do
                      _, id = GetActionInfo(i)
-                     if id == 77606 then   darksim[1] = i;   darksim[2] = 0;   if debugg then print("DKROT:Dark Simulacrum Action Slot "..i)end; break; end
+                     if id == 77606 then
+                        darksim[1] = i
+                        darksim[2] = 0
+                        DKROT:Debug("Dark Simulacrum Action Slot " .. i)
+                        break
+                     end
                   end
                end
                _, id = GetActionInfo(darksim[1])
@@ -810,7 +810,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                end
             end
 
-            --if its on a target then its a debuff, otherwise its a buff
+            -- if its on a target then its a debuff, otherwise its a buff
             if DKROT.Cooldowns.Buffs[DKROT_Settings.CD[DKROT.Current_Spec][location][1]][1] == "target" then
                _, _, icon, count, _, dur, expirationTime = UnitDebuff("target", DKROT_Settings.CD[DKROT.Current_Spec][location][1])
             else
@@ -818,7 +818,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             end
             frame.Icon:SetTexture(icon)
 
-            --If not an aura, set time
+            -- If not an aura, set time
             if icon ~= nil and ceil(expirationTime - curtime) > 0 then
                frame.Icon:SetVertexColor(0.5, 0.5, 0.5, 1)
                frame.Time:SetText(formatTime(ceil(expirationTime - curtime)))
@@ -828,10 +828,10 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
 
 
 
-         elseif inTable(DKROT.Cooldowns.Moves, DKROT_Settings.CD[DKROT.Current_Spec][location][1]) then --Move
+         elseif inTable(DKROT.Cooldowns.Moves, DKROT_Settings.CD[DKROT.Current_Spec][location][1]) then -- Move
             icon = GetSpellTexture(DKROT_Settings.CD[DKROT.Current_Spec][location][1])
             if icon ~= nil then
-               --Check if move is off CD
+               -- Check if move is off CD
                if DKROT:isOffCD(DKROT_Settings.CD[DKROT.Current_Spec][location][1]) and IsUsableSpell(DKROT_Settings.CD[DKROT.Current_Spec][location][1]) then
                   icon = DKROT:GetRangeandIcon(frame.Icon, DKROT_Settings.CD[DKROT.Current_Spec][location][1])
                else
@@ -840,7 +840,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             end
             frame.Icon:SetTexture(icon)
          elseif DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1 or
-            DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT2 then --Trinkets
+            DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT2 then -- Trinkets
 
             local id
             if DKROT_Settings.CD[DKROT.Current_Spec][location][1] == DKROT_OPTIONS_CDR_CD_TRINKETS_SLOT1 then
@@ -856,7 +856,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             if trink ~= nil then
                local altbuff = false
 
-               --Buff
+               -- Buff
                _, _, icon, count, _, dur, expirationTime = UnitBuff("player",trink[1])
                if icon == nil and trink[6] ~= nil then
                   _, _, icon, count, _, dur, expirationTime = UnitBuff("player",trink[6])
@@ -869,13 +869,13 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                   if count > 1 then frame.Stack:SetText(count) end
                   if (not altbuff) and (not trink[5]) then trink[5] = true; trink[4] = curtime end
 
-               --ICD or Use CD
+               -- ICD or Use CD
                else
                   local start, dur, active
                   frame.Icon:SetTexture(GetItemIcon(id))
-                  if trink[2] then --On-Use
+                  if trink[2] then -- On-Use
                      start, dur, active = GetItemCooldown(trink[3])
-                  else --ICD
+                  else -- ICD
                      trink[5] = false
                      dur, start = trink[3], trink[4]
                      active = 1
@@ -903,7 +903,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                end
             end
 
-         else --Cooldown
+         else -- Cooldown
             icon = DKROT:GetRangeandIcon(frame.Icon, DKROT_Settings.CD[DKROT.Current_Spec][location][1])
             frame.Icon:SetTexture(icon)
             if icon ~= nil then
@@ -916,7 +916,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                end
             end
          end
-         --if the icon is nil, then just hide the frame
+         -- if the icon is nil, then just hide the frame
          if frame.Icon:GetTexture() == nil then
             frame:SetAlpha(0)
          end
@@ -926,7 +926,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
    end
 
-   --Used to move individual frames where they are suppose to be displayed, also enables and disables mouse depending on settings
+   -- Used to move individual frames where they are suppose to be displayed, also enables and disables mouse depending on settings
    function DKROT:MoveFrame(self)
       self:ClearAllPoints()
       self:SetPoint(DKROT_Settings.Location[self:GetName()].Point, DKROT_Settings.Location[self:GetName()].Rel, DKROT_Settings.Location[self:GetName()].RelPoint, DKROT_Settings.Location[self:GetName()].X, DKROT_Settings.Location[self:GetName()].Y)
@@ -947,7 +947,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
    end
 
-   --Called to update all the frames positions and scales
+   -- Called to update all the frames positions and scales
    function DKROT:UpdatePosition()
       DKROT:MoveFrame(DKROT.MainFrame)
       DKROT:MoveFrame(DKROT.CD[1])
@@ -972,7 +972,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
 
       DKROT.MainFrame:SetScale(DKROT_Settings.Scale)
-      if debugg then print("DKROT:UpdatePosition")end
+      DKROT:Debug("UpdatePosition")
    end
 
    -- Return the duration and start/duration of the GCD or 0,nil,nil if GCD is ready
@@ -985,7 +985,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
    end
 
-   --Main function for updating all information
+   -- Main function for updating all information
    function DKROT:UpdateUI()
       if (UnitCanAttack("player", "target") and (not UnitIsDead("target"))) then
          DKROT.MainFrame:SetAlpha(DKROT_Settings.NormTrans)
@@ -993,14 +993,14 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT.MainFrame:SetAlpha(DKROT_Settings.CombatTrans)
       end
 
-      --GCD
+      -- GCD
       local gcdStart, gcdDur
       GCD, gcdStart, gcdDur = DKROT:GetGCD()
       if DKROT_Settings.GCD and GCD ~= 0 then
          DKROT.Move.c:SetCooldown(gcdStart, gcdDur)
       end
 
-      --Runes
+      -- Runes
       DKROT.RuneBar:SetAlpha((DKROT_Settings.Rune and 1) or 0)
       DKROT.RuneBarHolder:SetAlpha((DKROT_Settings.RuneBars and 1) or 0)
       if DKROT_Settings.Rune or DKROT_Settings.RuneBars then
@@ -1060,7 +1060,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT.RuneBar.Text:SetText(RuneBar)
       end
 
-      --RunicPower
+      -- RunicPower
       if DKROT_Settings.RP then
          DKROT.RunicPower:SetAlpha(1)
          r, g, b = unpack(RUNE_COLOUR[3])
@@ -1069,7 +1069,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT.RunicPower:SetAlpha(0)
       end
 
-      --Diseases
+      -- Diseases
       if DKROT_Settings.Disease then
          DKROT.Diseases:SetAlpha(1)
          DKROT.Diseases.FF.Icon:SetVertexColor(1, 1, 1, 1)
@@ -1093,7 +1093,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT.Diseases:SetAlpha(0)
       end
 
-      --Priority Icon
+      -- Priority Icon
       DKROT.Move.AOE:SetAlpha(0)
       DKROT.Move.Interrupt:SetAlpha(0)
       if DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][1] ~= DKROT_OPTIONS_FRAME_VIEW_NONE then
@@ -1101,9 +1101,9 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT.MoveBackdrop:SetAlpha(1)
          DKROT:UpdateCD("DKROT_CDRPanel_DD_Priority", DKROT.Move)
 
-         --If Priority on Main Icon
+         -- If Priority on Main Icon
          if DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][1] == DKROT_OPTIONS_CDR_CD_PRIORITY then
-            if DKROT_Settings.MoveAltInterrupt then --Show Interrupt
+            if DKROT_Settings.MoveAltInterrupt then -- Show Interrupt
                local spell, notint = select(1, UnitCastingInfo("target")), select(9, UnitCastingInfo("target"))
                if spell == nil then spell, notint = select(1, UnitChannelInfo("target")), select(8, UnitChannelInfo("target")) end
                if spell ~= nil and not notint then
@@ -1118,7 +1118,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT.MoveBackdrop:SetAlpha(0)
       end
 
-      --CDs
+      -- CDs
       for i = 1, #CDDisplayList do
          if DKROT_Settings.CD[DKROT.Current_Spec][ceil(i/2)] then
             DKROT.CD[ceil(i/2)]:SetAlpha(1)
@@ -1140,13 +1140,13 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                   bsamount = temp
                end
             end
-            --print(select(1, UnitBuff("player", i)).." "..select(11, UnitBuff("player", i)))
+            -- print(select(1, UnitBuff("player", i)).." "..select(11, UnitBuff("player", i)))
          end
       end
    end
 
-   do --Disease Tracker
-      --Create a DT Frame
+   do -- Disease Tracker
+      -- Create a DT Frame
       function DKROT:DTCreateFrame()
          frame = CreateFrame('StatusBar', nil, DKROT.DT)
          frame:SetHeight(24)
@@ -1162,15 +1162,15 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          return frame
       end
 
-      --Gather the info and apply them to it's frame
+      -- Gather the info and apply them to it's frame
       function DKROT:DTUpdateInfo(guid, info)
          if (not DKROT_Settings.DT.Target) and UnitGUID("target") == guid then return end
 
-         --Create Frame
+         -- Create Frame
          if info.Frame == nil then info.Frame = DKROT:DTCreateFrame() end
          info.Frame:SetAlpha(DKROT_Settings.DTTrans)
 
-         --Set Settings
+         -- Set Settings
          if info.spot == nil or info.spot ~= DKROT.DT.spot then
             info.spot = DKROT.DT.spot
             info.Frame:ClearAllPoints()
@@ -1178,19 +1178,19 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             else info.Frame:SetPoint("BOTTOM", 0, (DKROT.DT.spot*27)+1) end
          end
 
-         --Change Colour
+         -- Change Colour
          if DKROT_Settings.DT.TColours then
             if (UnitGUID("target") == guid) then info.Frame:SetBackdropColor(0.1, 0.75, 0.1, 0.9)
             elseif (UnitGUID("focus") == guid) then info.Frame:SetBackdropColor(0.2, 0.2, 0.75, 0.9)
             else info.Frame:SetBackdropColor(0, 0, 0, 0.5) end
          end
 
-         --Threat
+         -- Threat
          info.Frame:SetMinMaxValues(DKROT_Settings.DT.Threat, 100)
          if DKROT_Settings.DT.Threat ~= THREAT_OFF and info.Threat ~= nil then info.Frame:SetValue(info.Threat)
          else info.Frame:SetValue(0)   end
 
-         --Name
+         -- Name
          local name = info.Name
          local color
          if DKROT_Settings.DT.CColours then color = RAID_CLASS_COLORS[select(2, GetPlayerInfoByGUID(guid))] end
@@ -1198,7 +1198,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          name = (string.len(name) > 9 and string.gsub(name, '%s?(.)%S+%s', '%1. ') or name)
          info.Frame.Name:SetText(string.format("|cff%02x%02x%02x%.9s|r", color.r*255, color.g*255, color.b*255, name))
 
-         --Dots
+         -- Dots
          if info.Frame.Icons == nil or info.OldDots ~= info.NumDots then
             local count = 0
             local texture
@@ -1219,7 +1219,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             end
          end
 
-         --Update Dots
+         -- Update Dots
          if info.Frame.Icons ~= nil and next(info.Spells) ~= nil then
             for j, v in pairs(info.Spells) do
                if v ~= nil and info.Frame.Icons[j]~= nil then
@@ -1248,7 +1248,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT.DT.spot = DKROT.DT.spot + 1
       end
 
-      --Update the frames
+      -- Update the frames
       function DKROT:DTUpdateFrames()
          local function updateGUIDFrame(guid)
             if DKROT.DT.Unit[guid] ~= nil then
@@ -1276,7 +1276,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          end
       end
 
-      --Update Threat and Dots from checking target infos
+      -- Update Threat and Dots from checking target infos
       local updatedGUIDs = {}
       function DKROT:DTCheckTargets()
          local function updateGUIDInfo(unit)
@@ -1333,27 +1333,38 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
    end
 
-   do --Priority System
-      --Called to update a priority icon with next move
+   -- Priority System
+   do
+      -- Called to update a priority icon with next move
       function DKROT:GetNextMove(icon)
-         --Call correct function based on spec
-         if (DKROT.Current_Spec == DKROT.SPECS.UNHOLY) then
-            if DKROT_Settings.MoveAltAOE then DKROT.Move.AOE:SetAlpha(1); DKROT.Move.AOE.Icon:SetTexture(DKROT:UnholyAOEMove(DKROT.Move.AOE.Icon)) end
-            return DKROT:UnholyMove(icon)
-         elseif (DKROT.Current_Spec == DKROT.SPECS.FROST) then
-            if DKROT_Settings.MoveAltAOE then DKROT.Move.AOE:SetAlpha(1); DKROT.Move.AOE.Icon:SetTexture(DKROT:FrostAOEMove(DKROT.Move.AOE.Icon)) end
-            return DKROT:FrostMove(icon)
-         elseif (DKROT.Current_Spec == DKROT.SPECS.BLOOD) then
-            if DKROT_Settings.MoveAltAOE then DKROT.Move.AOE:SetAlpha(1); DKROT.Move.AOE.Icon:SetTexture(DKROT:BloodAOEMove(DKROT.Move.AOE.Icon)) end
-            return DKROT:BloodMove(icon)
+         -- Call correct function based on spec
+         if DKROT_Settings.MoveAltAOE then
+            if (DKROT.Current_Spec == DKROT.SPECS.UNHOLY) then
+               DKROT.Move.AOE:SetAlpha(1)
+               DKROT.Move.AOE.Icon:SetTexture(DKROT:UnholyAOEMove(DKROT.Move.AOE.Icon))
+
+            elseif (DKROT.Current_Spec == DKROT.SPECS.FROST) then
+               DKROT.Move.AOE:SetAlpha(1)
+               DKROT.Move.AOE.Icon:SetTexture(DKROT:FrostAOEMove(DKROT.Move.AOE.Icon))
+
+            elseif (DKROT.Current_Spec == DKROT.SPECS.BLOOD) then
+               DKROT.Move.AOE:SetAlpha(1)
+               DKROT.Move.AOE.Icon:SetTexture(DKROT:BloodAOEMove(DKROT.Move.AOE.Icon))
+            end
+         end
+
+         -- return DKROT.Rotations[DKROT.Current_Spec][DKROT_Settings.CD[DKROT.Current_Spec].Rotation].func(icon)
+         local nextCast, noCheckRange = DKROT.Rotations[DKROT.Current_Spec][DKROT_Settings.CD[DKROT.Current_Spec].Rotation].func()
+         if noCheckRange ~= nil and noCheckRange == true then
+            return GetSpellTexture(nextCast)
          else
-            return DKROT:BlankMove(icon)
+            return DKROT:GetRangeandIcon(icon, nextCast)
          end
       end
 
-      --Determines if player is in range with spell and sets colour and icon accordingly
-      --In: icon: icon in which to change the vertex colour of   move: spellID of spell to be cast next
-      --Out: returns the texture of the icon (probably unessesary since icon is now being passed in, will look into it more)
+      -- Determines if player is in range with spell and sets colour and icon accordingly
+      -- In: icon: icon in which to change the vertex colour of   move: spellID of spell to be cast next
+      -- Out: returns the texture of the icon (probably unessesary since icon is now being passed in, will look into it more)
       function DKROT:GetRangeandIcon(icon, move)
          if move ~= nil then
             if DKROT_Settings.Range and IsSpellInRange(move, "target") == 0 then
@@ -1363,29 +1374,30 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             end
             return GetSpellTexture(move)
          end
+
          return nil
       end
 
-      --Gives CD of rune type specified
-      --In: r: type of rune set to be queried
-      --Out:  time1: the lowest cd of the 2 runes being queried  time2: the higher of the cds  RT1: returns true if lowest cd rune is a death rune, RT2: same as RT1 except higher CD rune
+      -- Gives CD of rune type specified
+      -- In: r: type of rune set to be queried
+      -- Out:  time1: the lowest cd of the 2 runes being queried  time2: the higher of the cds  RT1: returns true if lowest cd rune is a death rune, RT2: same as RT1 except higher CD rune
       function DKROT:RuneCDs(r)
-         --Get individual rune numbers
+         -- Get individual rune numbers
          local a, b
          if r == DKROT.SPECS.UNHOLY then a, b = 3, 4
          elseif r == DKROT.SPECS.FROST then a, b = 5, 6
          elseif r == DKROT.SPECS.BLOOD then a, b = 1, 2
          end
 
-         --Get CD of first rune
+         -- Get CD of first rune
          local start, dur, cool = GetRuneCooldown(a)
          time1 = (cool and 0) or (dur - (curtime - start + GCD))
 
-         --Get CD of second rune
+         -- Get CD of second rune
          local start, dur, cool = GetRuneCooldown(b)
          time2 = (cool and 0) or (dur - (curtime - start + GCD))
 
-         --if second rune will be off CD before first, then return second then first rune, else vice versa
+         -- if second rune will be off CD before first, then return second then first rune, else vice versa
          if time1 > time2 then
             return time2, time1, GetRuneType(b) == 4, GetRuneType(a) == 4
          else
@@ -1435,7 +1447,19 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          return count
       end
 
-      --Returns if move is off cooldown or not
+      function DKROT:HasFullyDepletedRunes()
+         if isRuneOffCD(1) ~= true and isRuneOffCD(2) ~= true then
+            return true
+         elseif isRuneOffCD(3) ~= true and isRuneOffCD(4) ~= true then
+            return true
+         elseif isRuneOffCD(5) ~= true and isRuneOffCD(6) ~= true then
+            return true
+         end
+
+         return false
+      end
+
+      -- Returns if move is off cooldown or not
       function DKROT:QuickAOESpellCheck(move)
          if DKROT_Settings.MoveAltAOE and GetSpellTexture(move) ~= nil then
             if DKROT:isOffCD(move) then
@@ -1445,182 +1469,148 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          return false
       end
 
-      --Determines if Diseases need to be refreshed or applied
-      function DKROT:GetDisease(icon)
-         --If settings not to worry about diseases, then break
-         if DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption == DISEASE_NONE then return false end
+      function DKROT:GetDiseaseTime()
+         local ff, bp
 
-         --Get Duration left on diseases
+         local expires = select(7,UnitDebuff("TARGET", DKROT.spells["Frost Fever"], nil, "PLAYER"))
+         if expires ~= nil then
+            ff = expires - curtime
+         end
+
+         expires = select(7,UnitDebuff("TARGET", DKROT.spells["Blood Plague"], nil, "PLAYER"))
+         if expires ~= nil then
+            bp = expires - curtime
+         end
+
+         expires = select(7, UnitDebuff("TARGET", DKROT.spells["Necrotic Plague"], nil, "PLAYER"))
+         if expires ~= nil then
+            local np = expires - curtime
+            ff = np
+            bp = np
+         end
+
+         return ff, bp
+      end
+
+      -- Determines if Diseases need to be refreshed or applied
+      function DKROT:GetDisease()
+         -- If settings not to worry about diseases, then break
+         if DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption == DISEASE_NONE then
+            return nil
+         end
+
+         -- Get Duration left on diseases
          local FFexpires, BPexpires, NPexpires
          local expires = select(7,UnitDebuff("TARGET", DKROT.spells["Frost Fever"], nil, "PLAYER"))
-         if  expires ~= nil then   FFexpires = expires - curtime end
+         if expires ~= nil then
+            FFexpires = expires - curtime
+         end
+
          expires = select(7,UnitDebuff("TARGET", DKROT.spells["Blood Plague"], nil, "PLAYER"))
-         if expires ~= nil then BPexpires = expires - curtime end
+         if expires ~= nil then
+            BPexpires = expires - curtime
+         end
+
          expires = select(7, UnitDebuff("TARGET", DKROT.spells["Necrotic Plague"], nil, "PLAYER"))
-         if expires ~= nil then NPexpires = expires - curtime end
+         if expires ~= nil then
+            NPexpires = expires - curtime
+         end
 
-         --Check if Outbreak is off CD, is known and Player wants to use it in rotation
-         local outbreak = DKROT_Settings.CD[DKROT.Current_Spec].Outbreak and IsSpellKnown(77575) and DKROT:isOffCD(DKROT.spells["Outbreak"])
+         -- Check if Outbreak is off CD, is known and Player wants to use it in rotation
+         local outbreak = DKROT_Settings.CD[DKROT.Current_Spec].Outbreak and
+            IsSpellKnown(77575) and
+            DKROT:isOffCD(DKROT.spells["Outbreak"])
 
-         --Check if Unholy Blight is up, is known and Player wants to use it in rotation
-         local unholyblight = DKROT_Settings.CD[DKROT.Current_Spec].UB and IsSpellKnown(115989) and DKROT:isOffCD(DKROT.spells["Unholy Blight"])
+         -- Check if Unholy Blight is up, is known and Player wants to use it in rotation
+         local unholyblight = DKROT_Settings.CD[DKROT.Current_Spec].UB and
+            IsSpellKnown(115989) and
+            DKROT:isOffCD(DKROT.spells["Unholy Blight"])
 
-         --Check if Plague Leech is up, is known and Player wants to use it in rotation
-         local plagueleech = DKROT_Settings.CD[DKROT.Current_Spec].PL and IsSpellKnown(123693) and DKROT:isOffCD(DKROT.spells["Plague Leech"])
+         -- Check if Plague Leech is up, is known and Player wants to use it in rotation
+         local plagueleech = DKROT_Settings.CD[DKROT.Current_Spec].PL and
+            IsSpellKnown(123693) and
+            DKROT:isOffCD(DKROT.spells["Plague Leech"])
 
 
          -- Apply Frost Fever
          if (FFexpires == nil or FFexpires < 2) and NPexpires == nil then
-            if outbreak then --if can use outbreak, then do it
-               return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Outbreak"])
-            elseif unholyblight then --if can use Unholy Blight, then do it
-               return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Unholy Blight"])
-            elseif (DKROT.Current_Spec == DKROT.SPECS.UNHOLY) and ((DKROT:RuneCDs(DKROT.SPECS.UNHOLY) <= 0) or DKROT:DeathRunes() >= 1) then --Unholy: Plague Strike
-               return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
-            elseif (DKROT.Current_Spec == DKROT.SPECS.FROST) and ((DKROT:RuneCDs(DKROT.SPECS.FROST) <= 0) or DKROT:DeathRunes() >= 1) then --Frost: Howling Blast
-               return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
-            elseif ((DKROT:RuneCDs(DKROT.SPECS.FROST) <= 0) or DKROT:DeathRunes() >= 1) then --Other: Icy Touch
-               return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Icy Touch"])
+            if outbreak then -- if can use outbreak, then do it
+               return DKROT.spells["Outbreak"]
+
+            elseif unholyblight then -- if can use Unholy Blight, then do it
+               return DKROT.spells["Unholy Blight"]
+
+            elseif (DKROT.Current_Spec == DKROT.SPECS.UNHOLY) and ((DKROT:RuneCDs(DKROT.SPECS.UNHOLY) <= 0) or DKROT:DeathRunes() >= 1) then -- Unholy: Plague Strike
+               return DKROT.spells["Plague Strike"]
+
+            elseif (DKROT.Current_Spec == DKROT.SPECS.FROST) and ((DKROT:RuneCDs(DKROT.SPECS.FROST) <= 0) or DKROT:DeathRunes() >= 1) then -- Frost: Howling Blast
+               return DKROT.spells["Howling Blast"]
+               
+            elseif ((DKROT:RuneCDs(DKROT.SPECS.FROST) <= 0) or DKROT:DeathRunes() >= 1) then -- Other: Icy Touch
+               return DKROT.spells["Icy Touch"]
             end
          end
 
-         --Apply Blood Plague
+         -- Apply Blood Plague
          if (DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption ~= DISEASE_ONE or outbreak) then
             if (BPexpires == nil or BPexpires < 3) then
                -- Necrotic plague acts as both frost fever and blood plague
                if NPexpires ~= nil and NPexpires > 3 then
-                  return false
+                  return nil
                end
 
                -- Add Death Grip as first priority until PS is in range
                if DKROT_Settings.DG and (IsSpellInRange(DKROT.spells["Plague Strike"], "target")) == 0 and IsUsableSpell(DKROT.spells["Death Grip"]) then
-                  return true, (DKROT:GetRangeandIcon(icon, DKROT.spells["Death Grip"]))
+                  return DKROT.spells["Death Grip"]
                end
 
                if plagueleech and (BPexpires ~= nil or NPexpires ~= nil) and DKROT:DepletedRunes() > 0 then
-                  return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Leech"])
+                  return DKROT.spells["Plague Leech"]
 
-               elseif outbreak then --if can use outbreak, then do it
-                  return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Outbreak"])
+               elseif outbreak then -- if can use outbreak, then do it
+                  return DKROT.spells["Outbreak"]
 
-               elseif unholyblight then --if can use Unholy Blight, then do it
-                  return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Unholy Blight"])
+               elseif unholyblight then -- if can use Unholy Blight, then do it
+                  return DKROT.spells["Unholy Blight"]
 
-               elseif ((DKROT:RuneCDs(DKROT.SPECS.UNHOLY) <= 0) or DKROT:DeathRunes() >= 1) then --if rune availible, then use Plague Strike
-                  return true, DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
+               elseif ((DKROT:RuneCDs(DKROT.SPECS.UNHOLY) <= 0) or DKROT:DeathRunes() >= 1) then -- if rune availible, then use Plague Strike
+                  return DKROT.spells["Plague Strike"]
                end
             end
          end
-         return false
-      end
 
-      --Function to determine rotation for No Spec
-      function DKROT:BlankMove(icon)
-         --Rune Info
-         local frost = DKROT:RuneCDs(DKROT.SPECS.FROST)
-         local unholy = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
-         local blood = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
-         local death = DKROT:DeathRunes()
-         local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
-
-         --Diseases
-         local disease, move = DKROT:GetDisease(icon)
-         if disease then   return move   end
-
-         -- Death Pact
-         if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
-            and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
-         then
-            if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
-               return GetSpellTexture(DKROT.spells["Death Pact"])
-            end
-         end
-
-         --Blood Tap with >= 11 Charges
-         if GetSpellTexture(DKROT.spells["Blood Tap"])
-            and DKROT_Settings.CD[DKROT.Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 11
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
-         end
-
-         --Death Coil if overcaped RP
-         if DKROT_Settings.CD[DKROT.Current_Spec].RP
-         and UnitPower("player") > 80 then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
-         end
-
-         --Death Strike
-         if GetSpellTexture(DKROT.spells["Death Strike"]) then
-            if select(1,IsUsableSpell(DKROT.spells["Death Strike"])) then
-               return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Strike"])
-            end
-         elseif select(1,IsUsableSpell(DKROT.spells["Icy Touch"])) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Icy Touch"])
-         elseif select(1,IsUsableSpell(DKROT.spells["Plague Strike"])) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
-         end
-
-         --Blood Boil
-         if select(1,IsUsableSpell(DKROT.spells["Blood Boil"])) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Boil"])
-         end
-
-         --Death Coil
-         if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") >= 40 then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
-         end
-
-         --Blood Tap with >= 5 Charges
-         if GetSpellTexture(DKROT.spells["Blood Tap"])
-            and DKROT_Settings.CD[DKROT.Current_Spec].BT
-            and bloodCharges ~= nil and bloodCharges >= 5
-            and (frost >= 0 or unholy >= 0 or blood >= 0)
-         then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
-         end
-
-         --Empower Rune Weapon
-         if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
-         and DKROT_Settings.CD[DKROT.Current_Spec].ERW then
-            if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
-               return DKROT:GetRangeandIcon(icon, DKROT.spells["Empower Rune Weapon"])
-            end
-         end
-
-         -- If nothing else can be done
          return nil
       end
 
-      --Function to determine AOE rotation for Unholy Spec
+
+      -- Function to determine AOE rotation for Unholy Spec
       function DKROT:UnholyAOEMove(icon)
          -- Diseases > Dark Transformation > Death and Decay > SS if both Unholy and/or all Death runes are up >
          -- BB + IT if both pairs of Blood and Frost runes are up >   DC
          -- > SS > BB + IT
 
-         --Rune Info
+         -- Rune Info
          local frost, lfrost, fd, lfd = DKROT:RuneCDs(DKROT.SPECS.FROST)
          local unholy, lunholy = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
          local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
          local death = DKROT:DeathRunes()
 
-         --AOE:Death and Decay
+         -- AOE:Death and Decay
          if DKROT:QuickAOESpellCheck(DKROT.spells["Death and Decay"]) and (unholy <= 0 or death >= 1) then
             return DKROT:GetRangeandIcon(icon, DKROT.spells["Death and Decay"])
          end
 
-         --AOE:Blood Boil
+         -- AOE:Blood Boil
          if DKROT:QuickAOESpellCheck(DKROT.spells["Blood Boil"]) and (blood <= 0 or death >= 1) then
             return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Boil"])
          end
 
-         --Scourge Strike
+         -- Scourge Strike
          if (lunholy <= 0) then
             return DKROT:GetRangeandIcon(icon, nil)
          end
 
-         --AOE:Death Coil
+         -- AOE:Death Coil
          if DKROT_Settings.CD[DKROT.Current_Spec].RP
          and (UnitPower("player") >= 40
             or select(7, UnitBuff("PLAYER",DKROT.spells["Sudden Doom"])) ~= nil) then
@@ -1630,46 +1620,46 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          return nil
       end
 
-      --Function to determine AOE rotation for Frost Spec
+      -- Function to determine AOE rotation for Frost Spec
       function DKROT:FrostAOEMove(icon)
 
-         --Rune Info
+         -- Rune Info
          local frost, lfrost, fd, lfd = DKROT:RuneCDs(DKROT.SPECS.FROST)
          local unholy, lunholy, ud, lud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
          local blood, lblood = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
          local death = DKROT:DeathRunes()
 
-         --AOE:Howling Blast if both Frost runes and/or both Death runes are up
+         -- AOE:Howling Blast if both Frost runes and/or both Death runes are up
          if DKROT:QuickAOESpellCheck(DKROT.spells["Howling Blast"]) and ((lfrost <= 0) or (lblood <= 0) or (lunholy <= 0 and lud)) then
             return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
          end
 
-         --AOE:DnD if both Unholy Runes are up
+         -- AOE:DnD if both Unholy Runes are up
          if DKROT:QuickAOESpellCheck(DKROT.spells["Death and Decay"]) and (lunholy <= 0) then
             return DKROT:GetRangeandIcon(icon, DKROT.spells["Death and Decay"])
          end
 
-         --AOE:Frost Strike if RP capped
+         -- AOE:Frost Strike if RP capped
          if DKROT:QuickAOESpellCheck(DKROT.spells["Frost Strike"]) and (UnitPower("player") > 88) then
             return DKROT:GetRangeandIcon(icon, nil)
          end
 
-         --AOE:Howling Blast
+         -- AOE:Howling Blast
          if DKROT:QuickAOESpellCheck(DKROT.spells["Howling Blast"]) and (frost <= 0 or death >= 1) then
             return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
          end
 
-         --AOE:DnD
+         -- AOE:DnD
          if DKROT:QuickAOESpellCheck(DKROT.spells["Death and Decay"]) and (unholy <= 0) then
             return DKROT:GetRangeandIcon(icon, DKROT.spells["Death and Decay"])
          end
 
-         --AOE:Frost Strike
+         -- AOE:Frost Strike
          if DKROT:QuickAOESpellCheck(DKROT.spells["Frost Strike"]) and UnitPower("player") >= 20 then
             return DKROT:GetRangeandIcon(icon, nil)
          end
 
-         --AOE:PS
+         -- AOE:PS
          if DKROT:QuickAOESpellCheck(DKROT.spells["Plague Strike"]) and (unholy <= 0) then
             return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
          end
@@ -1677,23 +1667,23 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          return nil
       end
 
-      --Function to determine AOE rotation for Blood Spec
+      -- Function to determine AOE rotation for Blood Spec
       function DKROT:BloodAOEMove(icon)
          return nil
       end
 
    end
 
-   --Function to check spec and presence
+   -- Function to check spec and presence
    function DKROT:CheckSpec()
-      --Set all settings to default
+      -- Set all settings to default
       DKROT.Current_Spec = DKROT.SPECS.UNKNOWN
       if GetSpecialization() == 1 then DKROT.Current_Spec = DKROT.SPECS.BLOOD
       elseif GetSpecialization() == 2 then DKROT.Current_Spec = DKROT.SPECS.FROST
       elseif GetSpecialization() == 3 then DKROT.Current_Spec = DKROT.SPECS.UNHOLY
       end
 
-      --Presence
+      -- Presence
       PLAYER_PRESENCE = 0
       for i = 1, GetNumShapeshiftForms() do
          local icon, _, active = GetShapeshiftFormInfo(i)
@@ -1702,17 +1692,17 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          end
       end
 
-      if debugg then print("DKROT:Check Spec - "..DKROT.Current_Spec)end
+      DKROT:Debug("Check Spec - " .. DKROT.Current_Spec)
       DKROT:OptionsRefresh()
    end
 
    local delayedInit = false
    function DKROT:Initialize()
-      if debugg then print("DKROT:Initialize")end
+      DKROT:Debug("Initialize")
       if InCombatLockdown() then
          if delayedInit == false then
             delayedInit = true
-            print('DKROT:Delaying initialization due to combat lockdown')
+            DKROT:Log("Delaying initialization due to combat lockdown")
          end
 
          return
@@ -1721,21 +1711,31 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
 
       DKROT:LoadSpells()
       DKROT:LoadCooldowns()
-      if not DKROT:LoadTrinkets() and (curtime - launchtime < ITEM_LOAD_THRESHOLD)then if debugg then print("DKROT:Initialize Failed")end; mutex = false; return; end
-      if debugg and (curtime - launchtime >= ITEM_LOAD_THRESHOLD) then print("DKROT:Launch Threshold Met") end
 
-      if debugg then
-         print("~~DKROT:Spell Difference Start~~")
-         for k, v in pairs (spells) do
-            if v == nil or k ~= v then print (k.." =/= ".. v)   end
-         end
-         print("~~DKROT:Spell Difference End~~")
+      if not DKROT:LoadTrinkets() and (curtime - launchtime < ITEM_LOAD_THRESHOLD) then
+         DKROT:Debug("Initialize Failed")
+         mutex = false
+         return
       end
 
-      --DKROT:SetDefaults()
-      --Check Settings
+      if (curtime - launchtime >= ITEM_LOAD_THRESHOLD) then
+         DKROT:Debug("Launch Threshold Met")
+      end
+
+      if DKROT.debug then
+         DKROT:Debug("~~Spell Difference Start~~")
+         for k, v in pairs(DKROT.spells) do
+            if v == nil or k ~= v then
+               DKROT:Debug(k.." =/= ".. v)
+            end
+         end
+         DKROT:Debug("~~Spell Difference End~~")
+      end
+
+      -- DKROT:SetDefaults()
+      -- Check Settings
       DKROT:CheckSettings()
-      if debugg then print("DKROT:Initialize - Version "..DKROT_Settings.Version)end
+      DKROT:Debug("Initialize - Version " .. DKROT_Settings.Version)
 
       if DKROT_Settings.DT.Combat or not DKROT_Settings.DT.Enable then
          DKROT.MainFrame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
@@ -1747,7 +1747,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       DKROT:CreateCDs()
       DKROT:CreateUI()
 
-      --Setup Button Facade if enabled
+      -- Setup Button Facade if enabled
       if LBF then
          LBF:Group("DKROT"):Skin(unpack(DKROT_Settings.lbf))
          LBF:Group("DKROT"):AddButton(DKROT.Diseases.FF)
@@ -1773,28 +1773,32 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             mgrp:AddButton(DKROT.CD[CDDisplayList[i]])
          end
       end
+      
+      local PosPanel = DKROT:SetupPositionPanel()
 
       InterfaceOptions_AddCategory(DKROT_Options)
       InterfaceOptions_AddCategory(DKROT_FramePanel)
       InterfaceOptions_AddCategory(DKROT_CDRPanel)
       InterfaceOptions_AddCategory(DKROT_CDPanel)
       InterfaceOptions_AddCategory(DKROT_DTPanel)
+      -- InterfaceOptions_AddCategory(DKROT_PositionPanel)
+      -- InterfaceOptions_AddCategory(PosPanel)
       InterfaceOptions_AddCategory(DKROT_ABOUTPanel)
 
       DKROT_CDRPanel_DG_Text:SetText(DKROT.spells["Death Grip"])
+      DKROT:CheckSpec()
 
-      --Initalize all dropdowns
+      -- Initalize all dropdowns
       UIDropDownMenu_Initialize(DKROT_FramePanel_Rune_DD, DKROT_Rune_DD_OnLoad)
       UIDropDownMenu_Initialize(DKROT_CDRPanel_Diseases_DD, DKROT_Diseases_OnLoad)
       UIDropDownMenu_Initialize(DKROT_CDRPanel_DD_Priority, DKROT_CDRPanel_DD_OnLoad)
+      UIDropDownMenu_Initialize(DKROT_CDRPanel_Rotation, DKROT_Rotations_OnLoad)
       for i = 1, #CDDisplayList do
          UIDropDownMenu_Initialize(_G[CDDisplayList[i]], DKROT_CDRPanel_DD_OnLoad)
       end
       UIDropDownMenu_Initialize(DKROT_FramePanel_ViewDD, DKROT_FramePanel_ViewDD_OnLoad)
       UIDropDownMenu_Initialize(DKROT_DTPanel_DD_Threat, DKROT_DTPanel_Threat_OnLoad)
-      if debugg then print("DKROT:Initialize - Dropdowns Done")end
-
-      DKROT:CheckSpec()
+      DKROT:Debug("Initialize - Dropdowns Done")
 
       mutex = nil
       loaded = true
@@ -1802,21 +1806,20 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       collectgarbage()
    end
 
-   if debugg then print("DKROT:Functions Done")end
+   DKROT:Debug("Functions Done")
 
-   -----Events-----
-   --Register Events
+   -- --- Events-- ---
+   -- Register Events
    DKROT.MainFrame:RegisterEvent("PLAYER_TALENT_UPDATE")
    DKROT.MainFrame:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED")
-   --DKROT:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
-   --DKROT:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+   -- DKROT:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
+   -- DKROT:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
 
-   --Function to be called when events triggered
+   -- Function to be called when events triggered
    local slottimer = 0
    DKROT.MainFrame:SetScript("OnEvent", function(_, e, ...)
       -- Delayed addon initialization due to combat lockdown
       if loaded then
-         --if debugg then print("DKROT:Event "..e)end
          if e == "COMBAT_LOG_EVENT_UNFILTERED" then
             local _, event, _, _, casterName, _, _,targetguid, targetName, _, _, _, spellName = ...
             if (event == "UNIT_DIED" or event == "UNIT_DESTROYED") and DKROT.DT.Unit[targetguid] ~= nil then
@@ -1860,21 +1863,21 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
    end)
 
-   --Main function to run addon
+   -- Main function to run addon
    local DTupdatetimer = 0
    local DTchecktimer = 0
    local scheduledInit = false
    DKROT.MainFrame:SetScript("OnUpdate", function()
       curtime = GetTime()
-      --Make sure it only updates at max, once every 0.15 sec
+      -- Make sure it only updates at max, once every 0.15 sec
       if (curtime - updatetimer >= 0.08) then
          updatetimer = curtime
 
          if (not loaded) and (not mutex) then
-            if launchtime == 0 then launchtime = curtime;if debugg then print("DKROT:Launchtime Set")end end
+            if launchtime == 0 then launchtime = curtime;DKROT:Debug("Launchtime Set") end
             DKROT:Initialize()
          elseif loaded then
-            --Check if visibility conditions are met, if so update the information in the addon
+            -- Check if visibility conditions are met, if so update the information in the addon
             if (not UnitHasVehicleUI("player")) and
                   ((InCombatLockdown() and DKROT_Settings.VScheme == DKROT_OPTIONS_FRAME_VIEW_NORM) or
                   (DKROT_Settings.VScheme == DKROT_OPTIONS_FRAME_VIEW_SHOW) or
@@ -1918,19 +1921,19 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
    end)
 
-   -----Options-----
-   --Setup slash command
+   -- --- Options-- ---
+   -- Setup slash command
    SLASH_DKROT1 = '/dkrot'
    SlashCmdList["DKROT"] = function()
       InterfaceOptionsFrame_OpenToCategory(DKROT_FramePanel)
       InterfaceOptionsFrame_OpenToCategory(DKROT_FramePanel)
-      if debugg then print("DKROT:Slash Command Used")end
+      DKROT:Debug("Slash Command Used")
    end
 
-   --Update the Blizzard interface Options with settings
+   -- Update the Blizzard interface Options with settings
    function DKROT:OptionsRefresh()
       if DKROT_Settings ~= nil and DKROT_Settings.Version ~= nil and DKROT_Settings.Version == DKROT_VERSION then
-         --Frame
+         -- Frame
          DKROT_FramePanel_GCD:SetChecked(DKROT_Settings.GCD)
          DKROT_FramePanel_CDS:SetChecked(DKROT_Settings.CDS)
          DKROT_FramePanel_CDEDGE:SetChecked(DKROT_Settings.CDEDGE)
@@ -1950,7 +1953,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT_FramePanel_NormalTrans:SetNumber(DKROT_Settings.NormTrans)
          DKROT_FramePanel_NormalTrans:SetCursorPosition(0)
 
-         --View Dropdown
+         -- View Dropdown
          UIDropDownMenu_SetSelectedValue(DKROT_FramePanel_ViewDD, DKROT_Settings.VScheme)
          UIDropDownMenu_SetText(DKROT_FramePanel_ViewDD, DKROT_Settings.VScheme)
 
@@ -1958,7 +1961,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          UIDropDownMenu_SetText(DKROT_FramePanel_Rune_DD, DKROT_OPTIONS_FRAME_RUNE_ORDER[DKROT_Settings.RuneOrder])
 
 
-         --CD/R
+         -- CD/R
          DKROT_CDRPanel_Outbreak_Text:SetText(DKROT.spells["Outbreak"])
          DKROT_CDRPanel_UB_Text:SetText(DKROT.spells["Unholy Blight"])
          DKROT_CDRPanel_PL_Text:SetText(DKROT.spells["Plague Leech"])
@@ -1968,31 +1971,45 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          if (DKROT.Current_Spec == DKROT.SPECS.UNHOLY) then
             DKROT_CDRPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_UNHOLY)
             DKROT_CDPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_UNHOLY)
-            DKROT_CDRPanel_AltRot_Text:SetText(DKROT_OPTIONS_CDR_ALT_ROT.." ("..DKROT_OPTIONS_CDR_ALT_ROT_UNHOLY..")")
-            DKROT_CDRPanel_AltRot:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].AltRot)
          elseif (DKROT.Current_Spec == DKROT.SPECS.FROST) then
             DKROT_CDRPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_FROST)
             DKROT_CDPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_FROST)
-            DKROT_CDRPanel_AltRot_Text:SetText(DKROT_OPTIONS_CDR_ALT_ROT.." ("..DKROT_OPTIONS_CDR_ALT_ROT_FROST..")")
-            DKROT_CDRPanel_AltRot:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].AltRot)
          elseif (DKROT.Current_Spec == DKROT.SPECS.BLOOD) then
             DKROT_CDRPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_BLOOD)
             DKROT_CDPanel_Title_Spec:SetText(DKROT_OPTIONS_SPEC_BLOOD)
-            DKROT_CDRPanel_AltRot_Text:SetText(DKROT_OPTIONS_CDR_ALT_ROT.." ("..DKROT_OPTIONS_CDR_ALT_ROT_BLOOD..")")
-            DKROT_CDRPanel_AltRot:Disable()
-            DKROT_CDRPanel_AltRot:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].AltRot)
          else
             DKROT_CDRPanel_Title_Spec:SetText(DKROT_OPTIONS_DKROT_SPEC_None)
             DKROT_CDPanel_Title_Spec:SetText(DKROT_OPTIONS_DKROT_SPEC_None)
          end
 
-         --Disease Dropdown
+         -- Disease Dropdown
          UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Diseases_DD, DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption)
+
          local text
-         if DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption == DISEASE_BOTH then text = DKROT_OPTIONS_CDR_DISEASES_DD_BOTH
-         elseif DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption == DISEASE_ONE then text = DKROT_OPTIONS_CDR_DISEASES_DD_ONE
-         else text =   DKROT_OPTIONS_CDR_DISEASES_DD_NONE end
+         if DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption == DISEASE_BOTH then
+            text = DKROT_OPTIONS_CDR_DISEASES_DD_BOTH
+         elseif DKROT_Settings.CD[DKROT.Current_Spec].DiseaseOption == DISEASE_ONE then
+            text = DKROT_OPTIONS_CDR_DISEASES_DD_ONE
+         else
+            text = DKROT_OPTIONS_CDR_DISEASES_DD_NONE
+         end
          UIDropDownMenu_SetText(DKROT_CDRPanel_Diseases_DD, text)
+
+         -- Rotation
+         local current_rotation = DKROT_Settings.CD[DKROT.Current_Spec].Rotation
+         if current_rotation == nil then
+            if DKROT.Current_Spec ~= DKROT.SPECS.UNKNOWN then
+               for rotName, rotInfo in pairs(DKROT.Rotations[DKROT.Current_Spec]) do
+                  if rotInfo.default == true then
+                     print('Setting default rotation: ' .. rotName)
+                     current_rotation = rotName
+                     break
+                  end
+               end
+               UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Rotation, current_rotation)
+               UIDropDownMenu_SetText(DKROT_CDRPanel_Rotation, DKROT.Rotations[DKROT.Current_Spec][current_rotation].name)
+            end
+         end
 
          DKROT_CDRPanel_Outbreak:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].Outbreak)
          DKROT_CDRPanel_UB:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec].UB)
@@ -2004,19 +2021,20 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT_CDRPanel_MoveAltInterrupt:SetChecked(DKROT_Settings.MoveAltInterrupt)
          DKROT_CDRPanel_MoveAltAOE:SetChecked(DKROT_Settings.MoveAltAOE)
          DKROT_CDRPanel_MoveAltDND:SetChecked(DKROT_Settings.MoveAltDND)
+         DKROT_CDRPanel_UseHoW:SetChecked(DKROT_Settings.UseHoW)
          DKROT_CDRPanel_DG:SetChecked(DKROT_Settings.DG)
          DKROT_CDRPanel_DD_CD1:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec][1])
          DKROT_CDRPanel_DD_CD2:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec][2])
          DKROT_CDRPanel_DD_CD3:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec][3])
          DKROT_CDRPanel_DD_CD4:SetChecked(DKROT_Settings.CD[DKROT.Current_Spec][4])
 
-         --Priority Dropdown
+         -- Priority Dropdown
          if DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"] ~= nil and DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][1] ~= nil then
             UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_DD_Priority, DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][1]..((DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][IS_BUFF] and " (Buff)") or ""))
             UIDropDownMenu_SetText(DKROT_CDRPanel_DD_Priority, DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][1]..((DKROT_Settings.CD[DKROT.Current_Spec]["DKROT_CDRPanel_DD_Priority"][IS_BUFF] and " (Buff)") or ""))
          end
 
-         --Cooldown Dropdown
+         -- Cooldown Dropdown
          for i = 1, #CDDisplayList do
             if _G[CDDisplayList[i]] ~= nil and DKROT_Settings.CD[DKROT.Current_Spec][CDDisplayList[i]] ~= nil and DKROT_Settings.CD[DKROT.Current_Spec][CDDisplayList[i]][1] ~= nil then
                UIDropDownMenu_SetSelectedValue(_G[CDDisplayList[i]], DKROT_Settings.CD[DKROT.Current_Spec][CDDisplayList[i]][1]..((DKROT_Settings.CD[DKROT.Current_Spec][CDDisplayList[i]][IS_BUFF] and " (Buff)") or ""))
@@ -2024,7 +2042,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             end
          end
 
-         --Disease Tracker
+         -- Disease Tracker
          DKROT_DTPanel_Enable:SetChecked(DKROT_Settings.DT.Enable)
          DKROT_DTPanel_CColours:SetChecked(DKROT_Settings.DT.CColours)
          DKROT_DTPanel_TColours:SetChecked(DKROT_Settings.DT.TColours)
@@ -2059,7 +2077,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT_DTPanel_DOTS_NP_Text:SetText(DKROT.spells["Necrotic Plague"])
          DKROT_DTPanel_DOTS_NP:SetChecked(DKROT_Settings.DT.Dots[DKROT.spells["Necrotic Plague"]])
 
-         --About Options
+         -- About Options
          local expText = "<html><body>"
                .."<p>"..DKROT_ABOUT_BODY.."</p>"
                .."<p><br/>"
@@ -2072,17 +2090,17 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT_ABOUTHTML:SetText (expText);
          DKROT_ABOUTHTML:SetSpacing (2);
 
-         if debugg then print("DKROT:OptionsRefresh")end
+         DKROT:Debug("OptionsRefresh")
          DKROT:UpdatePosition()
       else
-         if debugg then print("DKROT:ERROR OptionsRefresh - "..(DKROT_Settings == nil and "Settings are nil") or (DKROT_Settings.Version == nil and "Version is nil") or ("Invalid Version"..DKROT_Settings.Version ))end
+         DKROT:Debug("ERROR OptionsRefresh - " .. (DKROT_Settings == nil and "Settings are nil") or (DKROT_Settings.Version == nil and "Version is nil") or ("Invalid Version" .. DKROT_Settings.Version))
       end
    end
 
-   --Check if options are valid and save them to settings if so
+   -- Check if options are valid and save them to settings if so
    function DKROT_OptionsOkay()
       if DKROT_Settings ~= nil and (DKROT_Settings.Version ~= nil and DKROT_Settings.Version == DKROT_VERSION) then
-         --Frame
+         -- Frame
          DKROT_Settings.GCD = DKROT_FramePanel_GCD:GetChecked()
          DKROT_Settings.CDEDGE = DKROT_FramePanel_CDEDGE:GetChecked()
          DKROT_Settings.CDS = DKROT_FramePanel_CDS:GetChecked()
@@ -2095,14 +2113,14 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT_Settings.Locked = DKROT_FramePanel_Locked:GetChecked()
          DKROT_Settings.LockedPieces = DKROT_FramePanel_LockedPieces:GetChecked()
 
-         --Scale
+         -- Scale
          if DKROT_FramePanel_Scale:GetNumber() >= 0.5 and DKROT_FramePanel_Scale:GetNumber() <= 5 then
             DKROT_Settings.Scale = DKROT_FramePanel_Scale:GetNumber()
          else
             DKROT_FramePanel_Scale:SetNumber(DKROT_Settings.Scale)
          end
 
-         --Transparency
+         -- Transparency
          if DKROT_FramePanel_Trans:GetNumber() >= 0 and DKROT_FramePanel_Trans:GetNumber() <= 1 then
             DKROT_Settings.Trans = DKROT_FramePanel_Trans:GetNumber()
          else
@@ -2119,12 +2137,12 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             DKROT_FramePanel_NormalTrans:SetNumber(DKROT_Settings.NormTrans)
          end
 
-         --CD/R
+         -- CD/R
          DKROT_Settings.MoveAltInterrupt = DKROT_CDRPanel_MoveAltInterrupt:GetChecked()
          DKROT_Settings.MoveAltAOE = DKROT_CDRPanel_MoveAltAOE:GetChecked()
          DKROT_Settings.MoveAltDND = DKROT_CDRPanel_MoveAltDND:GetChecked()
+         DKROT_Settings.UseHoW = DKROT_CDRPanel_UseHoW:GetChecked()
          DKROT_Settings.DG = DKROT_CDRPanel_DG:GetChecked()
-         DKROT_Settings.CD[DKROT.Current_Spec].AltRot = DKROT_CDRPanel_AltRot:GetChecked()
          DKROT_Settings.CD[DKROT.Current_Spec].Outbreak = DKROT_CDRPanel_Outbreak:GetChecked()
          DKROT_Settings.CD[DKROT.Current_Spec].UB = DKROT_CDRPanel_UB:GetChecked()
          DKROT_Settings.CD[DKROT.Current_Spec].PL = DKROT_CDRPanel_PL:GetChecked()
@@ -2137,7 +2155,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT_Settings.CD[DKROT.Current_Spec][3] = (DKROT_CDRPanel_DD_CD3:GetChecked())
          DKROT_Settings.CD[DKROT.Current_Spec][4] = (DKROT_CDRPanel_DD_CD4:GetChecked())
 
-         --Disease Timers
+         -- Disease Timers
          DKROT_Settings.DT.Enable = DKROT_DTPanel_Enable:GetChecked()
          if not DKROT_Settings.DT.Enable then
             for k, v in pairs(DKROT.DT.Unit) do
@@ -2187,20 +2205,21 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          -- Change the cooldown spiral edge settings
          DKROT.Move.c:SetDrawEdge(DKROT_Settings.CDEDGE)
 
-         if debugg then print("DKROT:OptionsOkay")end
+         DKROT:Debug("OptionsOkay")
          DKROT:OptionsRefresh()
       else
-         if debugg then print("DKROT:ERROR OptionsOkay - "..(DKROT_Settings == nil and "Settings are nil") or (DKROT_Settings.Version == nil and "Version is nil") or ("Invalid Version"..DKROT_Settings.Version))end
+         DKROT:Debug("ERROR OptionsOkay - " .. (DKROT_Settings == nil and "Settings are nil") or (DKROT_Settings.Version == nil and "Version is nil") or ("Invalid Version" .. DKROT_Settings.Version))
       end
    end
 
-   --Cooldown Defaults
+   -- Cooldown Defaults
    function DKROT:CooldownDefaults()
       if DKROT_Settings.CD ~= nil then wipe(DKROT_Settings.CD) end
       DKROT_Settings.CD = {
          [DKROT.SPECS.UNHOLY] = {
             ["DKROT_CDRPanel_DD_Priority"] = {DKROT_OPTIONS_CDR_CD_PRIORITY, nil},
             DiseaseOption = DISEASE_BOTH,
+            Rotation = DKROT:GetDefaultSpecRotation(DKROT.SPECS.UNHOLY),
             Outbreak = true,
             RP = true,
             UB = false,
@@ -2226,6 +2245,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          [DKROT.SPECS.FROST] = {
             ["DKROT_CDRPanel_DD_Priority"] = {DKROT_OPTIONS_CDR_CD_PRIORITY, nil},
             DiseaseOption = DISEASE_BOTH,
+            Rotation = DKROT:GetDefaultSpecRotation(DKROT.SPECS.FROST),
             Outbreak = true,
             RP = true,
             UB = true,
@@ -2252,6 +2272,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          [DKROT.SPECS.BLOOD] = {
             ["DKROT_CDRPanel_DD_Priority"] = {DKROT_OPTIONS_CDR_CD_PRIORITY, nil},
             DiseaseOption = DISEASE_BOTH,
+            Rotation = DKROT:GetDefaultSpecRotation(DKROT.SPECS.BLOOD),
             Outbreak = true,
             RP = true,
             UB = true,
@@ -2279,6 +2300,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          [DKROT.SPECS.UNKNOWN] = {
             ["DKROT_CDRPanel_DD_Priority"] = {DKROT_OPTIONS_CDR_CD_PRIORITY, nil},
             DiseaseOption = DISEASE_BOTH,
+            Rotation = DKROT:GetDefaultSpecRotation(DKROT.SPECS.UNKNOWN),
             Outbreak = true,
             RP = true,
             UB = true,
@@ -2303,14 +2325,14 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       }
    end
 
-   --Checks to make sure that none of the settings are nil, which will lead to the addon not working properly
+   -- Checks to make sure that none of the settings are nil, which will lead to the addon not working properly
    function DKROT:CheckSettings()
-      if debugg then print("DKROT:Check Settings Start")end
+      DKROT:Debug("Check Settings Start")
 
       local specs = {DKROT.SPECS.UNKNOWN, DKROT.SPECS.BLOOD, DKROT.SPECS.FROST, DKROT.SPECS.UNHOLY}
       local spots = {"Priority", "CD1_One", "CD1_Two", "CD2_One", "CD2_Two", "CD3_One", "CD3_Two", "CD4_One", "CD4_Two"}
 
-      --Defaults
+      -- Defaults
       if DKROT_Settings == nil then
          DKROT_Settings = {}
          DKROT_Settings.Locked = true
@@ -2325,7 +2347,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT:CooldownDefaults()
       end
 
-      --General Settings
+      -- General Settings
       if DKROT_Settings.lbf == nil then DKROT_Settings.lbf = { 'Blizzard', 0, nil }end
       if DKROT_Settings.Scale == nil then DKROT_Settings.Scale = 1.0 end
       if DKROT_Settings.RuneOrder == nil then  DKROT_Settings.RuneOrder = BBUUFF end
@@ -2335,7 +2357,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if DKROT_Settings.DTTrans == nil then DKROT_Settings.DTTrans = 1.0 end
       if DKROT_Settings.VScheme == nil then DKROT_Settings.VScheme = DKROT_OPTIONS_FRAME_VIEW_NORM end
 
-      --CDs
+      -- CDs
       if DKROT_Settings.CD == nil then
          DKROT_Settings.CD = {}
          DKROT:CooldownDefaults()
@@ -2351,7 +2373,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          end
       end
 
-      --DT
+      -- DT
       if DKROT_Settings.DT == nil then
          DKROT_Settings.DT = {}
          DKROT_Settings.DT.Enable = true
@@ -2371,7 +2393,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          DKROT_Settings.DT.Dots[DKROT.spells["Death and Decay"]] = true
       end
 
-      --Frame Location
+      -- Frame Location
       if DKROT_Settings.Location == nil then DKROT_Settings.Location = {} end
       if DKROT_Settings.Location["DKROT"] == nil then   DKROT_Settings.Location["DKROT"] = {Point = "Center", Rel = nil, RelPoint = "CENTER", X = 0, Y = -175, Scale = 1} end
       if DKROT_Settings.Location["DKROT.CD1"] == nil then   DKROT_Settings.Location["DKROT.CD1"] = {Point = "TOPRIGHT",Rel = "DKROT",RelPoint = "TOPLEFT", X = -1, Y = -3, Scale = 1} end
@@ -2390,25 +2412,25 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       wipe(specs)
       wipe(spots)
       collectgarbage()
-      if debugg then print("DKROT:Check Settings Complete")end
+      DKROT:Debug("Check Settings Complete")
    end
 
-   --Set frame location back to Defaults
+   -- Set frame location back to Defaults
    function DKROT:SetLocationDefault()
       if DKROT_Settings.Location ~= nil then wipe(DKROT_Settings.Location); DKROT_Settings.Location = nil end
       DKROT:CheckSettings()
 
       DKROT:OptionsRefresh()
-      if debugg then print("DKROT:SetLocationDefault Done")end
+      DKROT:Debug("SetLocationDefault Done")
    end
 
-   --Set all settings back to default
+   -- Set all settings back to default
    function DKROT:SetDefaults()
       if DKROT_Settings ~= nil then wipe(DKROT_Settings); DKROT_Settings = nil end
       DKROT:CheckSettings()
 
       DKROT:OptionsRefresh()
-      if debugg then print("DKROT:SetDefaults Done")end
+      DKROT:Debug("SetDefaults Done")
    end
 
    function DKROT_Rune_DD_OnLoad()
@@ -2475,7 +2497,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       UIDropDownMenu_AddButton(info)
    end
 
-   --function to handle the View dropdown box
+   -- function to handle the View dropdown box
    function DKROT_FramePanel_ViewDD_OnLoad()
       info            = {}
       info.text       = DKROT_OPTIONS_FRAME_VIEW_NORM
@@ -2502,7 +2524,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       UIDropDownMenu_AddButton(info)
    end
 
-   --function to handle the Disease dropdown box
+   -- function to handle the Disease dropdown box
    function DKROT_Diseases_OnLoad(self)
       info = {}
       info.text = DKROT_OPTIONS_CDR_DISEASES_DD_BOTH
@@ -2523,12 +2545,44 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       UIDropDownMenu_AddButton(info)
    end
 
-   --function to handle the CD dropdown boxes
+   -- Initialize the rotation list
+   function DKROT_Rotations_OnLoad(self)
+      for key, rotation in pairs(DKROT.Rotations[DKROT.Current_Spec]) do
+         info = {}
+         info.text = rotation.name
+         info.value = key
+         info.func = function()
+            DKROT_Settings.CD[DKROT.Current_Spec].Rotation = key
+            UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Rotation, DKROT_Settings.CD[DKROT.Current_Spec].Rotation)
+         end
+         UIDropDownMenu_AddButton(info)
+      end
+
+      -- Select rotation
+      local current_rotation = DKROT_Settings.CD[DKROT.Current_Spec].Rotation
+      if current_rotation == nil then
+         if DKROT.Current_Spec ~= DKROT.SPECS.UNKNOWN then
+            for rotName, rotInfo in pairs(DKROT.Rotations[DKROT.Current_Spec]) do
+               if rotInfo.default == true then
+                  current_rotation = rotName
+                  break
+               end
+            end
+            UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Rotation, current_rotation)
+            UIDropDownMenu_SetText(DKROT_CDRPanel_Rotation, DKROT.Rotations[DKROT.Current_Spec][current_rotation].name)
+         end
+      end
+
+      UIDropDownMenu_SetSelectedValue(DKROT_CDRPanel_Rotation, current_rotation)
+      UIDropDownMenu_SetText(DKROT_CDRPanel_Rotation, DKROT.Rotations[DKROT.Current_Spec][current_rotation].name)
+   end
+
+   -- function to handle the CD dropdown boxes
    function DKROT_CDRPanel_DD_OnLoad(self, level)
-      --If specified level, or base
+      -- If specified level, or base
       level = level or 1
 
-      --Template for an item in the dropdown box
+      -- Template for an item in the dropdown box
       local function DKROT_CDRPanel_DD_Item (panel, spell, buff)
          info = {}
          info.text = spell .. ((buff and " (Buff)") or "")
@@ -2542,7 +2596,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          return info
       end
 
-      --Function to add specs specific CDs
+      -- Function to add specs specific CDs
       local function AddSpecCDs(Spec)
          for i = 1, #Spec do
             if (DKROT.Cooldowns.Buffs[Spec[i]] == nil or DKROT.Cooldowns.Buffs[Spec[i]][2]) then
@@ -2554,46 +2608,46 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          end
       end
 
-      --If base level
+      -- If base level
       if level == 1 then
-         --Add unique items to dropdown
+         -- Add unique items to dropdown
          UIDropDownMenu_AddButton(DKROT_CDRPanel_DD_Item(self, DKROT_OPTIONS_CDR_CD_PRIORITY), 1)
          UIDropDownMenu_AddButton(DKROT_CDRPanel_DD_Item(self, DKROT_OPTIONS_CDR_CD_PRESENCE), 1)
          UIDropDownMenu_AddButton(DKROT_CDRPanel_DD_Item(self, DKROT_OPTIONS_FRAME_VIEW_NONE), 1)
          UIDropDownMenu_AddButton(DKROT_CDRPanel_DD_Item(self, DKROT_OPTIONS_CDR_RACIAL), 1)
 
-         --Setup nested dropdowns
+         -- Setup nested dropdowns
          info.hasArrow = true
          info.notClickable = 1
 
-         --Spec Specific CDs
+         -- Spec Specific CDs
          info.text = DKROT_OPTIONS_CDR_CD_SPEC
          info.value = {["Level1_Key"] = "Spec";}
          UIDropDownMenu_AddButton(info)
 
-         --Normal CDs
+         -- Normal CDs
          info.text = DKROT_OPTIONS_CDR_CD_NORMAL
          info.value = {["Level1_Key"] = "Normal";}
          UIDropDownMenu_AddButton(info)
 
-         --Moves
+         -- Moves
          info.text = DKROT_OPTIONS_CDR_CD_MOVES
          info.value = {["Level1_Key"] = "Moves";}
          UIDropDownMenu_AddButton(info)
 
-         --Talents
+         -- Talents
          info.text = DKROT_OPTIONS_CDR_CD_TALENTS
          info.value = {["Level1_Key"] = "Talents";}
          UIDropDownMenu_AddButton(info)
 
-         --Trinkets
+         -- Trinkets
          info.text = DKROT_OPTIONS_CDR_CD_TRINKETS
          info.value = {["Level1_Key"] = "Trinkets";}
          UIDropDownMenu_AddButton(info)
 
-      --If nested menu
+      -- If nested menu
       elseif level == 2 then
-         --Check what the "parent" is
+         -- Check what the "parent" is
          local key = UIDROPDOWNMENU_MENU_VALUE["Level1_Key"]
 
          if key == "Spec" then
@@ -2625,9 +2679,51 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
    end
 
+   -- Initialize the UI element drop down
+   function DKROT_PositionPanel_Elements_OnLoad(self)
+      local ui_elements = {
+         {
+            name = "Runic Power",
+            frame = "DKROT.RunicPower"
+         },
+         {
+            name = "Priority Icon",
+            frame = "DKROT.Move"
+         },
+         {
+            name = "Disease Tracker",
+            frame = "DKROT.DT"
+         },
+      }
+
+      for key, element in pairs(ui_elements) do
+         info = {}
+         info.text = element.name
+         info.value = element.frame
+         info.func = function()
+            local el = _G[element.frame]
+
+            DKROT_PositionPanel_Width:SetValue(el:GetWidth())
+            DKROT_PositionPanel_Height:SetValue(el:GetHeight())
+            DKROT_PositionPanel_Scale:SetValue(el:GetScale())
+
+            UIDropDownMenu_SetSelectedValue(DKROT_PositionPanel_Element, element.frame)
+         end
+         UIDropDownMenu_AddButton(info)
+      end
+   end
+
+   function DKROT:SetupPositionPanel()
+      UIDropDownMenu_Initialize(DKROT_PositionPanel_Element, DKROT_PositionPanel_Elements_OnLoad)
+   end
+
+   function DKROT_PositionUpdate()
+      print("Updating position / sizes of elements")
+   end
+
+   DKROT:Log("Loaded addon")
 else
-   if debugg then print("DKROT: Not a DK")end
-   debugg = nil
+   DKROT:Debug("Not a DK")
    DKROT_Options = nil
    DKROT_FramePanel = nil
    DKROT_CDRPanel = nil

--- a/helpers.lua
+++ b/helpers.lua
@@ -1,0 +1,66 @@
+if select(2, UnitClass("player")) == "DEATHKNIGHT" then
+   local _, DKROT = ...
+
+   -- Register a rotation
+   function DKROT_RegisterRotation(spec, intname, rotname, rotfunc, def)
+      local currentDefault = DKROT:GetDefaultSpecRotation(spec)
+      if currentDefault ~= nil and def == true then
+         local specName = select(2, GetSpecializationInfo(spec))
+         local defSpecName = DKROT.Rotations[spec][currentDefault].name
+         DKROT:Log("Cannot register " .. rotname .. " as the new default spec rotation for '" .. specName .. "' as there is already a default rotation (" .. defSpecName .. ") registered. Registering as non-default")
+         def = false
+      end
+      DKROT.Rotations[spec][intname] = {
+         name = rotname,
+         func = rotfunc,
+         default = def
+      }
+   end
+
+   -- Get default rotation for spec
+   function DKROT:GetDefaultSpecRotation(spec)
+      if spec == nil then
+         spec = DKROT.Current_Spec
+      end
+
+      for rotName, rotInfo in pairs(DKROT.Rotations[spec]) do
+         if rotInfo.default then
+            return rotName
+         end
+      end
+
+      return nil
+   end
+
+   -- Get spellID by name
+   function DKROT:GetSpellID(spell)
+      return select(7, GetSpellInfo(spell))
+   end
+
+   -- Check if we need to use Horn of Winter (missing buff)
+   function DKROT:UseHoW()
+      local battleShout = select(1, GetSpellInfo(6673))
+      local trueShotAura = select(1, GetSpellInfo(19506))
+      
+      if UnitBuff("PLAYER", DKROT.spells["Horn of Winter"]) ~= nil
+         or UnitBuff("PLAYER", battleShout) ~= nil
+         or UnitBuff("PLAYER", trueShotAura) ~= nil
+      then
+         return false
+      end
+
+      return true
+   end
+   
+   -- Chat log function
+   function DKROT:Log(message)
+      DEFAULT_CHAT_FRAME:AddMessage("|cFFC41F3BDKRot:|r " .. message)
+   end
+
+   -- Debug log function
+   function DKROT:Debug(message)
+      if DKROT.debug then
+         DEFAULT_CHAT_FRAME:AddMessage("|cFFC41F3BDKRot |cFF00FFFF[DEBUG]|r:|r " .. message)
+      end
+   end
+end

--- a/init.lua
+++ b/init.lua
@@ -1,13 +1,15 @@
 if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    local _, DKROT = ...
+   DKROT.debug = false
    DKROT_VERSION = GetAddOnMetadata("DKRot", "Version")
 
    DKROT.SPECS = {
-      UNKNOWN = 0,
       BLOOD = 1,
       FROST = 2,
-      UNHOLY = 3
+      UNHOLY = 3,
+      UNKNOWN = 4
    }
+
    DKROT.DTspells = {}
    DKROT.Current_Spec = DKROT.SPECS.UNKNOWN
    DKROT.spells = {}
@@ -18,11 +20,4 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       {},
       {},
    }
-
-   function DKROT:RegisterRotation(spec, intname, rotname, rotfunc)
-      DKROT.Rotations[spec][intname] = {
-         name = rotname,
-         func = rotfunc
-      }
-   end
 end

--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,28 @@
+if select(2, UnitClass("player")) == "DEATHKNIGHT" then
+   local _, DKROT = ...
+   DKROT_VERSION = GetAddOnMetadata("DKRot", "Version")
+
+   DKROT.SPECS = {
+      UNKNOWN = 0,
+      BLOOD = 1,
+      FROST = 2,
+      UNHOLY = 3
+   }
+   DKROT.DTspells = {}
+   DKROT.Current_Spec = DKROT.SPECS.UNKNOWN
+   DKROT.spells = {}
+   DKROT.Cooldowns = {}
+   DKROT.Rotations = {
+      {},
+      {},
+      {},
+      {},
+   }
+
+   function DKROT:RegisterRotation(spec, intname, rotname, rotfunc)
+      DKROT.Rotations[spec][intname] = {
+         name = rotname,
+         func = rotfunc
+      }
+   end
+end

--- a/rotations/blank.lua
+++ b/rotations/blank.lua
@@ -1,0 +1,89 @@
+if select(2, UnitClass("player")) == "DEATHKNIGHT" then
+   local _, DKROT = ...
+
+   -- Function to determine rotation for No Spec
+   local function BlankMove()
+      -- Rune Info
+      local frost = DKROT:RuneCDs(DKROT.SPECS.FROST)
+      local unholy = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+      local blood = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
+      local death = DKROT:DeathRunes()
+      local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
+
+      -- Diseases
+      local disease = DKROT:GetDisease()
+      if disease ~= nil then
+         return disease
+      end
+
+      -- Death Pact
+      if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
+         and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
+      then
+         if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
+            return DKROT.spells["Death Pact"], true
+         end
+      end
+
+      -- Blood Tap with >= 11 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 11
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT.spells["Blood Tap"], true
+      end
+
+      -- Death Coil if overcaped RP
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") > 80 then
+         return DKROT.spells["Death Coil"]
+      end
+
+      -- Death Strike
+      if GetSpellTexture(DKROT.spells["Death Strike"]) then
+         if select(1,IsUsableSpell(DKROT.spells["Death Strike"])) then
+            return DKROT.spells["Death Strike"]
+         end
+
+      elseif select(1, IsUsableSpell(DKROT.spells["Icy Touch"])) then
+         return DKROT.spells["Icy Touch"]
+
+      elseif select(1, IsUsableSpell(DKROT.spells["Plague Strike"])) then
+         return DKROT.spells["Plague Strike"]
+      end
+
+      -- Blood Boil
+      if select(1, IsUsableSpell(DKROT.spells["Blood Boil"])) then
+         return DKROT.spells["Blood Boil"]
+      end
+
+      -- Death Coil
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") >= 40 then
+         return DKROT.spells["Death Coil"]
+      end
+
+      -- Blood Tap with >= 5 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 5
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT.spells["Blood Tap"], true
+      end
+
+      -- Empower Rune Weapon if we have it enabled and we have at least 3 runes depleted
+      if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
+         and DKROT_Settings.CD[DKROT.Current_Spec].ERW
+         and DKROT:DepletedRunes() >= 3
+      then
+         if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
+            return DKROT.spells["Empower Rune Weapon"]
+         end
+      end
+
+      -- If nothing else can be done
+      return nil
+   end
+
+   DKROT_RegisterRotation(DKROT.SPECS.UNKNOWN, 'BlankMove', 'No Spec', BlankMove, true)
+end

--- a/rotations/blood.lua
+++ b/rotations/blood.lua
@@ -1,8 +1,8 @@
 if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    local _, DKROT = ...
 
-   local function IcyVeins(icon)
-      --Rune Info
+   local function IcyVeins()
+      -- Rune Info
       local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
       local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
       local blood, lblood = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
@@ -14,74 +14,81 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
       then
          if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
-            return GetSpellTexture(DKROT.spells["Death Pact"])
+            return DKROT.spells["Death Pact"], true
          end
       end
 
-      --Bone Shield
+      -- Bone Shield
       if GetSpellTexture(DKROT.spells["Bone Shield"]) ~= nil
-      and select(7, UnitBuff("player", DKROT.spells["Bone Shield"])) == nil   then
+         and select(7, UnitBuff("player", DKROT.spells["Bone Shield"])) == nil
+      then
          if DKROT:isOffCD(DKROT.spells["Bone Shield"]) then
-            return GetSpellTexture(DKROT.spells["Bone Shield"])
+            return DKROT.spells["Bone Shield"], true
          end
+      end
+
+      -- Horn of Winter
+      if DKROT_Settings.UseHoW and DKROT:UseHoW() then
+         return DKROT.spells["Horn of Winter"]
       end
 
       -- Defile
       if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
          if DKROT:isOffCD(DKROT.spells["Defile"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Defile"])
+            return DKROT.spells["Defile"], true
          end
       end
 
-      --Soul Reaper
+      -- Soul Reaper
       if lblood <= 2 and GetSpellTexture(DKROT.spells["Soul Reaper"]) ~= nil
          and UnitHealth("target")/UnitHealthMax("target") < 0.35
       then
          if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Soul Reaper"])
+            return DKROT.spells["Soul Reaper"]
          end
       end
 
-      --Diseases
-      local disease, move = DKROT:GetDisease(icon)
-      if disease then return move end
+      -- Diseases
+      local disease = DKROT:GetDisease()
+      if disease ~= nil then
+         return disease
+      end
 
-      --Death Strike
-      if GetSpellTexture(DKROT.spells["Death Strike"]) ~= nil
-      and select(1,IsUsableSpell(DKROT.spells["Death Strike"])) then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Strike"])
+      -- Death Strike
+      if GetSpellTexture(DKROT.spells["Death Strike"]) and select(1,IsUsableSpell(DKROT.spells["Death Strike"])) then
+         return DKROT.spells["Death Strike"]
       end
 
       -- Breath of Sindragosa
       if GetSpellTexture(DKROT.spells["Breath of Sindragosa"]) ~= nil and UnitPower("player") > 30 then
          if DKROT:isOffCD(DKROT.spells["Breath of Sindragosa"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Breath of Sindragosa"])
+            return DKROT.spells["Breath of Sindragosa"]
          end
       end
 
-      --Blood Tap with >= 11 Charges
+      -- Blood Tap with >= 11 Charges
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 11
          and (frost >= 0 or unholy >= 0 or blood >= 0)
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+         return DKROT.spells["Blood Tap"]
       end
 
-      --Blood Boil if we have a blood rune
+      -- Blood Boil if we have a blood rune
       if GetSpellTexture(DKROT.spells["Blood Boil"]) and blood <= 0 then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Boil"])
+         return DKROT.spells["Blood Boil"]
       end
 
-      --Death Coil
-      if UnitPower("player") >= 40 then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
+      -- Death Coil
+      if UnitPower("player") >= 30 then
+         return DKROT.spells["Death Coil"]
       end
 
-      --Crimson Scourge BB
+      -- Crimson Scourge BB
       if select(7,UnitBuff("player", DKROT.spells["Crimson Scourge"])) ~= nil then
          if DKROT_Settings.MoveAltDND then
-            --Death and Decay
+            -- Death and Decay
             if GetSpellTexture(DKROT.spells["Death and Decay"]) ~= nil then
                if DKROT:isOffCD(DKROT.spells["Death and Decay"]) then
                   DKROT.Move.AOE:SetAlpha(1)
@@ -89,37 +96,142 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                end
             end
          end
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Boil"])
+
+         return DKROT.spells["Blood Boil"]
       end
 
-      --Blood Tap with >= 5 Charges
+      -- Blood Tap with >= 5 Charges
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
          and (frost >= 0 or unholy >= 0 or blood >= 0)
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+         return DKROT.spells["Blood Tap"], true
       end
 
-      --Empower Rune Weapon if we have runes to activate and we're not RP capped
+      -- Empower Rune Weapon if we have it enabled and we have at least 3 runes depleted
       if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
          and DKROT_Settings.CD[DKROT.Current_Spec].ERW
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
-         and UnitPower("player") < 80
+         and DKROT:DepletedRunes() >= 3
       then
          if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Empower Rune Weapon"])
+            return DKROT.spells["Empower Rune Weapon"]
          end
       end
 
-      --If nothing else can be done
+      -- If nothing else can be done
       return nil
    end
 
-   DKROT:RegisterRotation(DKROT.SPECS.BLOOD, 'IcyVeins', 'Icy Veins', IcyVeins)
+   local function SimC()
+      -- Rune Info
+      local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
+      local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+      local blood, lblood = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
+      local death = DKROT:DeathRunes()
+      local bloodCharges = select(4,UnitBuff("player", DKROT.spells["Blood Charge"]))
+      local healthPct = (UnitHealth("PLAYER") / UnitHealthMax("PLAYER")) * 100
 
-   -- Function to determine rotation for Blood Spec
-   function DKROT:BloodMove(icon)
-      return DKROT.Rotations[DKROT.SPECS.BLOOD]["IcyVeins"]["func"](icon)
+      -- Death Pact
+      if GetSpellTexture(DKROT.spells["Death Pact"]) and healthPct < 50 then
+         if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
+            return DKROT.spells["Death Pact"], true
+         end
+      end
+
+      -- Bone Shield
+      if select(7, UnitBuff("player", DKROT.spells["Bone Shield"])) == nil then
+         if DKROT:isOffCD(DKROT.spells["Bone Shield"]) then
+            return DKROT.spells["Bone Shield"], true
+         end
+      end
+
+      -- Horn of Winter
+      if DKROT_Settings.UseHoW and DKROT:UseHoW() then
+         return DKROT.spells["Horn of Winter"], true
+      end
+
+      -- Lichborne
+      if GetSpellTexture(DKROT.spells["Lichborne"]) and UnitHealth("PLAYER") < 90 then
+         if DKROT:isOffCD(DKROT.spells["Lichborne"]) then
+            return DKROT.spells["Lichborne"], true
+         end
+      end
+
+      -- Death Strike if we are below 60% health
+      if healthPct < 60 and DKROT:isOffCD(DKROT.spells["Death Strike"]) then
+         return DKROT.spells["Death Strike"]
+      end
+
+      -- Defile
+      if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
+         if DKROT:isOffCD(DKROT.spells["Defile"]) then
+            return DKROT.spells["Defile"], true
+         end
+      end
+
+      -- Soul Reaper
+      if lblood <= 2 and GetSpellTexture(DKROT.spells["Soul Reaper"]) ~= nil
+         and UnitHealth("target")/UnitHealthMax("target") < 0.35
+      then
+         if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
+            return DKROT.spells["Soul Reaper"]
+         end
+      end
+
+      -- Diseases
+      local disease = DKROT:GetDisease()
+      if disease ~= nil then
+         return disease
+      end
+
+      -- Dancing Rune Weapon
+      if healthPct < 80 and DKROT:isOffCD(DKROT.spells["Dancing Rune Weapon"]) then
+         return DKROT.spells["Dancing Rune Weapon"], true
+      end
+
+      -- Death Strike
+      if (lunholy <= 0 or lfrost <= 0) and DKROT:isOffCD(DKROT.spells["Death Strike"]) then
+         return DKROT.spells["Death Strike"]
+      end
+
+      -- Death Coil if more than 70 RP
+      if UnitPower("PLAYER") >= 70 then
+         return DKROT.spells["Death Coil"]
+      end
+
+      -- Blood Boil if we have a blood rune
+      if lblood <= 0 or select(7,UnitBuff("player", DKROT.spells["Crimson Scourge"])) then
+         return DKROT.spells["Blood Boil"]
+      end
+
+      -- Blood Tap with >= 5 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 5
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT.spells["Blood Tap"], true
+      end
+
+      -- Death Coil
+      if UnitPower("player") >= 30 then
+         return DKROT.spells["Death Coil"]
+      end
+
+      -- Empower Rune Weapon if we have it enabled and we have at least 3 runes depleted
+      if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
+         and DKROT_Settings.CD[DKROT.Current_Spec].ERW
+         and DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"])
+         and DKROT:DepletedRunes() >= 3
+      then
+         return DKROT.spells["Empower Rune Weapon"]
+      end
+
+      -- If nothing else can be done
+      return nil
    end
+
+   DKROT_RegisterRotation(DKROT.SPECS.BLOOD, 'IcyVeins', 'Blood - Icy Veins', IcyVeins, true)
+   DKROT_RegisterRotation(DKROT.SPECS.BLOOD, 'SimC', 'Blood - SimCraft', SimC, false)
 end

--- a/rotations/blood.lua
+++ b/rotations/blood.lua
@@ -1,0 +1,125 @@
+if select(2, UnitClass("player")) == "DEATHKNIGHT" then
+   local _, DKROT = ...
+
+   local function IcyVeins(icon)
+      --Rune Info
+      local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
+      local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+      local blood, lblood = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
+      local death = DKROT:DeathRunes()
+      local bloodCharges = select(4,UnitBuff("player", DKROT.spells["Blood Charge"]))
+
+      -- Death Pact
+      if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
+         and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
+      then
+         if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
+            return GetSpellTexture(DKROT.spells["Death Pact"])
+         end
+      end
+
+      --Bone Shield
+      if GetSpellTexture(DKROT.spells["Bone Shield"]) ~= nil
+      and select(7, UnitBuff("player", DKROT.spells["Bone Shield"])) == nil   then
+         if DKROT:isOffCD(DKROT.spells["Bone Shield"]) then
+            return GetSpellTexture(DKROT.spells["Bone Shield"])
+         end
+      end
+
+      -- Defile
+      if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
+         if DKROT:isOffCD(DKROT.spells["Defile"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Defile"])
+         end
+      end
+
+      --Soul Reaper
+      if lblood <= 2 and GetSpellTexture(DKROT.spells["Soul Reaper"]) ~= nil
+         and UnitHealth("target")/UnitHealthMax("target") < 0.35
+      then
+         if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Soul Reaper"])
+         end
+      end
+
+      --Diseases
+      local disease, move = DKROT:GetDisease(icon)
+      if disease then return move end
+
+      --Death Strike
+      if GetSpellTexture(DKROT.spells["Death Strike"]) ~= nil
+      and select(1,IsUsableSpell(DKROT.spells["Death Strike"])) then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Strike"])
+      end
+
+      -- Breath of Sindragosa
+      if GetSpellTexture(DKROT.spells["Breath of Sindragosa"]) ~= nil and UnitPower("player") > 30 then
+         if DKROT:isOffCD(DKROT.spells["Breath of Sindragosa"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Breath of Sindragosa"])
+         end
+      end
+
+      --Blood Tap with >= 11 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 11
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+      end
+
+      --Blood Boil if we have a blood rune
+      if GetSpellTexture(DKROT.spells["Blood Boil"]) and blood <= 0 then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Boil"])
+      end
+
+      --Death Coil
+      if UnitPower("player") >= 40 then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
+      end
+
+      --Crimson Scourge BB
+      if select(7,UnitBuff("player", DKROT.spells["Crimson Scourge"])) ~= nil then
+         if DKROT_Settings.MoveAltDND then
+            --Death and Decay
+            if GetSpellTexture(DKROT.spells["Death and Decay"]) ~= nil then
+               if DKROT:isOffCD(DKROT.spells["Death and Decay"]) then
+                  DKROT.Move.AOE:SetAlpha(1)
+                  DKROT.Move.AOE.Icon:SetTexture(GetSpellTexture(DKROT.spells["Death and Decay"]))
+               end
+            end
+         end
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Boil"])
+      end
+
+      --Blood Tap with >= 5 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 5
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+      end
+
+      --Empower Rune Weapon if we have runes to activate and we're not RP capped
+      if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
+         and DKROT_Settings.CD[DKROT.Current_Spec].ERW
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and UnitPower("player") < 80
+      then
+         if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Empower Rune Weapon"])
+         end
+      end
+
+      --If nothing else can be done
+      return nil
+   end
+
+   DKROT:RegisterRotation(DKROT.SPECS.BLOOD, 'IcyVeins', 'Icy Veins', IcyVeins)
+
+   -- Function to determine rotation for Blood Spec
+   function DKROT:BloodMove(icon)
+      return DKROT.Rotations[DKROT.SPECS.BLOOD]["IcyVeins"]["func"](icon)
+   end
+end

--- a/rotations/frost.lua
+++ b/rotations/frost.lua
@@ -1,0 +1,266 @@
+if select(2, UnitClass("player")) == "DEATHKNIGHT" then
+   local _, DKROT = ...
+
+   local function IcyVeins2H(icon)
+      --Rune Info
+      local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
+      local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+      local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
+      local death = DKROT:DeathRunes()
+
+      -- Death Pact
+      if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
+         and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
+      then
+         if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
+            return GetSpellTexture(DKROT.spells["Death Pact"])
+         end
+      end
+
+      if GetSpellTexture(DKROT.spells["Soul Reaper"]) ~= nil
+         and UnitHealth("target")/UnitHealthMax("target") < 0.35
+      then
+         if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Soul Reaper"])
+         end
+      end
+
+      -- Defile
+      if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
+         if DKROT:isOffCD(DKROT.spells["Defile"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Defile"])
+         end
+      end
+
+      --Diseases
+      local disease, move = DKROT:GetDisease(icon)
+      if disease then return move end
+      local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
+
+      -- Breath of Sindragosa
+      if GetSpellTexture(DKROT.spells["Breath of Sindragosa"]) ~= nil and UnitPower("player") > 30 then
+         if DKROT:isOffCD(DKROT.spells["Breath of Sindragosa"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Breath of Sindragosa"])
+         end
+      end
+
+      --Obliterate with killing machine or runes overcaped
+      if GetSpellTexture(DKROT.spells["Obliterate"]) ~= nil
+         and select(1,IsUsableSpell(DKROT.spells["Obliterate"]))
+         and (select(7,UnitBuff("player", DKROT.spells["Killing Machine"])) ~= nil
+         or (lfrost <= 0 or lunholy <= 0 or (lblood <= 0 and lbd)))
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Obliterate"])
+      end
+
+      --Blood Tap with >= 11 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 11
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+      end
+
+      --Frost Strike if rp overcaped
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") > 76 then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Frost Strike"])
+      end
+
+      --Obliterate
+      if GetSpellTexture(DKROT.spells["Obliterate"]) ~= nil then
+         if select(1,IsUsableSpell(DKROT.spells["Obliterate"])) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Obliterate"])
+         end
+      else
+         --Howling Blast
+         if frost <= 0 then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+         end
+
+         --Plague Strike
+         if unholy <= 0 then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
+         end
+      end
+
+      --Rime Howling Blast
+      if select(7,UnitBuff("player", DKROT.spells["Freezing Fog"])) ~= nil then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+      end
+
+      --Frost Strike
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") >= 25 then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Frost Strike"])
+      end
+
+      --Blood Tap with >= 5 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 5
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+      end
+
+      --Empower Rune Weapon
+      if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
+      and DKROT_Settings.CD[DKROT.Current_Spec].ERW then
+         if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Empower Rune Weapon"])
+         end
+      end
+
+      -- If nothing else can be done
+      return nil
+   end
+      
+   local function IcyVeinsDualWield(icon)
+      --Rune Info
+      local frost, lfrost = DKROT:RuneCDs(DKROT.SPECS.FROST)
+      local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+      local blood, lblood = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
+      local death = DKROT:DeathRunes()
+      local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
+
+      -- Death Pact
+      if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
+         and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
+      then
+         if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
+            return GetSpellTexture(DKROT.spells["Death Pact"])
+         end
+      end
+
+      --Soul Reaper
+      if GetSpellTexture(DKROT.spells["Soul Reaper"]) ~= nil
+         and (death >= 1 or frost <= 0)
+         and UnitHealth("target")/UnitHealthMax("target") < 0.35
+      then
+         if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Soul Reaper"])
+         end
+      end
+
+      -- Defile
+      if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
+         if DKROT:isOffCD(DKROT.spells["Defile"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Defile"])
+         end
+      end
+
+      -- Breath of Sindragosa
+      if GetSpellTexture(DKROT.spells["Breath of Sindragosa"]) ~= nil and UnitPower("player") > 30 then
+         if DKROT:isOffCD(DKROT.spells["Breath of Sindragosa"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Breath of Sindragosa"])
+         end
+      end
+
+      --Blood Tap with >= 11 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 11
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+      end
+
+      --Frost Strike if Killing Machine is procced
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP
+         and UnitPower("player") >= 25
+         and select(7,UnitBuff("player", DKROT.spells["Killing Machine"])) ~= nil
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Frost Strike"])
+      end
+
+      --Frost Strike if RP capped
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") > 88 then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Frost Strike"])
+      end
+
+      --Diseases
+      local disease, move = DKROT:GetDisease(icon)
+      if disease then return move end
+
+      --Death and Decay
+      if GetSpellTexture(DKROT.spells["Death and Decay"]) ~= nil
+         and DKROT_Settings.MoveAltDND and lunholy <= 0
+      then
+         if DKROT:isOffCD(DKROT.spells["Death and Decay"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Death and Decay"])
+         end
+      end
+
+      --Howling Blast with both frost or both death off cooldown
+      if lblood <= 0 or lfrost <= 0 then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+      end
+
+      --Obliterate when Killing Machine is procced and both Unholy Runes are off cooldown
+      if GetSpellTexture(DKROT.spells["Obliterate"])~=nil
+         and select(1,IsUsableSpell(DKROT.spells["Obliterate"]))
+         and lunholy <= 0
+         and select(7,UnitBuff("player", DKROT.spells["Killing Machine"])) ~= nil
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Obliterate"])
+      end
+
+      --Howling Blast if Rime procced
+      if select(7,UnitBuff("player", DKROT.spells["Freezing Fog"])) ~= nil then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+      end
+
+      --Obliterate when second Unholy Rune is nearly off cooldown
+      if GetSpellTexture(DKROT.spells["Obliterate"])~=nil then
+         if lunholy <= 2 and not ud and (frost <= 0 or blood <= 0) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Obliterate"])
+         end
+      else --Plague Strike
+         if unholy <= 0 then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
+         end
+      end
+
+      --Howling Blast
+      if death >= 1 or frost <= 0 then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+      end
+
+      --Blood Tap with >= 5 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 5
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+      end
+
+      --Frost Strike
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") > 39 then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Frost Strike"])
+      end
+
+      --Empower Rune Weapon
+      if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
+      and DKROT_Settings.CD[DKROT.Current_Spec].ERW then
+         if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Empower Rune Weapon"])
+         end
+      end
+
+      --If nothing else can be done
+      return nil
+   end
+
+   DKROT:RegisterRotation(DKROT.SPECS.FROST, 'IcyVeins2H', 'Icy Veins - Twohand', IcyVeins2H)
+   DKROT:RegisterRotation(DKROT.SPECS.FROST, 'IcyVeinsDualWield', 'Icy Veins - Dual Wield', IcyVeinsDualWield)
+
+   -- Function to determine rotation for Frost Spec
+   function DKROT:FrostMove(icon)
+      if DKROT_Settings.CD[DKROT.Current_Spec].AltRot then
+         return DKROT.Rotations[DKROT.SPECS.FROST]["IcyVeinsDualWield"]["func"](icon)
+      end
+
+      return DKROT.Rotations[DKROT.SPECS.FROST]["IcyVeins2H"]["func"](icon)
+   end
+end

--- a/rotations/frost.lua
+++ b/rotations/frost.lua
@@ -1,113 +1,123 @@
 if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    local _, DKROT = ...
 
-   local function IcyVeins2H(icon)
-      --Rune Info
+   local function IcyVeins2H()
+      -- Rune Info
       local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
       local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
       local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
       local death = DKROT:DeathRunes()
+      local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
+ 
+      -- Horn of Winter
+      if DKROT_Settings.UseHoW and DKROT:UseHoW() then
+         return DKROT.spells["Horn of Winter"]
+      end
 
       -- Death Pact
       if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
          and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
       then
          if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
-            return GetSpellTexture(DKROT.spells["Death Pact"])
+            return DKROT.spells["Death Pact"], true
          end
       end
 
+      -- Soul Reaper
       if GetSpellTexture(DKROT.spells["Soul Reaper"]) ~= nil
          and UnitHealth("target")/UnitHealthMax("target") < 0.35
       then
          if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Soul Reaper"])
+            return DKROT.spells["Soul Reaper"]
          end
       end
 
       -- Defile
       if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
          if DKROT:isOffCD(DKROT.spells["Defile"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Defile"])
+            return DKROT.spells["Defile"], true
          end
       end
 
-      --Diseases
-      local disease, move = DKROT:GetDisease(icon)
-      if disease then return move end
-      local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
+      -- Diseases
+      local disease = DKROT:GetDisease()
+      if disease ~= nil then
+         return disease
+      end
 
       -- Breath of Sindragosa
       if GetSpellTexture(DKROT.spells["Breath of Sindragosa"]) ~= nil and UnitPower("player") > 30 then
          if DKROT:isOffCD(DKROT.spells["Breath of Sindragosa"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Breath of Sindragosa"])
+            return DKROT.spells["Breath of Sindragosa"]
          end
       end
 
-      --Obliterate with killing machine or runes overcaped
+      -- Obliterate with killing machine or runes overcaped
       if GetSpellTexture(DKROT.spells["Obliterate"]) ~= nil
          and select(1,IsUsableSpell(DKROT.spells["Obliterate"]))
          and (select(7,UnitBuff("player", DKROT.spells["Killing Machine"])) ~= nil
          or (lfrost <= 0 or lunholy <= 0 or (lblood <= 0 and lbd)))
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Obliterate"])
+         return DKROT.spells["Obliterate"]
       end
 
-      --Blood Tap with >= 11 Charges
+      -- Blood Tap with >= 11 Charges
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 11
          and (frost >= 0 or unholy >= 0 or blood >= 0)
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+         return DKROT.spells["Blood Tap"], true
       end
 
-      --Frost Strike if rp overcaped
+      -- Frost Strike if rp overcaped
       if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") > 76 then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Frost Strike"])
+         return DKROT.spells["Frost Strike"]
       end
 
-      --Obliterate
+      -- Obliterate
       if GetSpellTexture(DKROT.spells["Obliterate"]) ~= nil then
          if select(1,IsUsableSpell(DKROT.spells["Obliterate"])) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Obliterate"])
+            return DKROT.spells["Obliterate"]
          end
       else
-         --Howling Blast
+         -- Howling Blast
          if frost <= 0 then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+            return DKROT.spells["Howling Blast"]
          end
 
-         --Plague Strike
+         -- Plague Strike
          if unholy <= 0 then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
+            return DKROT.spells["Plague Strike"]
          end
       end
 
-      --Rime Howling Blast
+      -- Rime Howling Blast
       if select(7,UnitBuff("player", DKROT.spells["Freezing Fog"])) ~= nil then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+         return DKROT.spells["Howling Blast"]
       end
 
-      --Frost Strike
+      -- Frost Strike
       if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") >= 25 then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Frost Strike"])
+         return DKROT.spells["Frost Strike"]
       end
 
-      --Blood Tap with >= 5 Charges
+      -- Blood Tap with >= 5 Charges
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
          and (frost >= 0 or unholy >= 0 or blood >= 0)
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+         return DKROT.spells["Blood Tap"], true
       end
 
-      --Empower Rune Weapon
+      -- Empower Rune Weapon if we have it enabled and we have at least 3 runes depleted
       if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
-      and DKROT_Settings.CD[DKROT.Current_Spec].ERW then
+         and DKROT_Settings.CD[DKROT.Current_Spec].ERW
+         and DKROT:DepletedRunes() >= 3
+      then
          if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Empower Rune Weapon"])
+            return DKROT.spells["Empower Rune Weapon"]
          end
       end
 
@@ -115,44 +125,49 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       return nil
    end
       
-   local function IcyVeinsDualWield(icon)
-      --Rune Info
+   local function IcyVeinsDualWield()
+      -- Rune Info
       local frost, lfrost = DKROT:RuneCDs(DKROT.SPECS.FROST)
       local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
       local blood, lblood = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
       local death = DKROT:DeathRunes()
       local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
+ 
+      -- Horn of Winter
+      if DKROT_Settings.UseHoW and DKROT:UseHoW() then
+         return DKROT.spells["Horn of Winter"]
+      end
 
       -- Death Pact
       if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
          and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
       then
          if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
-            return GetSpellTexture(DKROT.spells["Death Pact"])
+            return DKROT.spells["Death Pact"], true
          end
       end
 
-      --Soul Reaper
+      -- Soul Reaper
       if GetSpellTexture(DKROT.spells["Soul Reaper"]) ~= nil
          and (death >= 1 or frost <= 0)
          and UnitHealth("target")/UnitHealthMax("target") < 0.35
       then
          if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Soul Reaper"])
+            return DKROT.spells["Soul Reaper"]
          end
       end
 
       -- Defile
       if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
          if DKROT:isOffCD(DKROT.spells["Defile"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Defile"])
+            return DKROT.spells["Defile"], true
          end
       end
 
       -- Breath of Sindragosa
       if GetSpellTexture(DKROT.spells["Breath of Sindragosa"]) ~= nil and UnitPower("player") > 30 then
          if DKROT:isOffCD(DKROT.spells["Breath of Sindragosa"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Breath of Sindragosa"])
+            return DKROT.spells["Breath of Sindragosa"]
          end
       end
 
@@ -162,7 +177,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          and bloodCharges ~= nil and bloodCharges >= 11
          and (frost >= 0 or unholy >= 0 or blood >= 0)
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+         return DKROT.spells["Blood Tap"], true
       end
 
       --Frost Strike if Killing Machine is procced
@@ -170,97 +185,218 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          and UnitPower("player") >= 25
          and select(7,UnitBuff("player", DKROT.spells["Killing Machine"])) ~= nil
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Frost Strike"])
+         return DKROT.spells["Frost Strike"]
       end
 
-      --Frost Strike if RP capped
+      -- Frost Strike if RP capped
       if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") > 88 then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Frost Strike"])
+         return DKROT.spells["Frost Strike"]
       end
 
-      --Diseases
-      local disease, move = DKROT:GetDisease(icon)
-      if disease then return move end
-
-      --Death and Decay
-      if GetSpellTexture(DKROT.spells["Death and Decay"]) ~= nil
-         and DKROT_Settings.MoveAltDND and lunholy <= 0
-      then
-         if DKROT:isOffCD(DKROT.spells["Death and Decay"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Death and Decay"])
-         end
+      -- Diseases
+      local disease = DKROT:GetDisease()
+      if disease ~= nil then
+         return disease
       end
 
-      --Howling Blast with both frost or both death off cooldown
+      -- Howling Blast with both frost or both death off cooldown
       if lblood <= 0 or lfrost <= 0 then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+         return DKROT.spells["Howling Blast"]
       end
 
-      --Obliterate when Killing Machine is procced and both Unholy Runes are off cooldown
+      -- Obliterate when Killing Machine is procced and both Unholy Runes are off cooldown
       if GetSpellTexture(DKROT.spells["Obliterate"])~=nil
          and select(1,IsUsableSpell(DKROT.spells["Obliterate"]))
          and lunholy <= 0
          and select(7,UnitBuff("player", DKROT.spells["Killing Machine"])) ~= nil
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Obliterate"])
+         return DKROT.spells["Obliterate"]
       end
 
-      --Howling Blast if Rime procced
+      -- Howling Blast if Rime procced
       if select(7,UnitBuff("player", DKROT.spells["Freezing Fog"])) ~= nil then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+         return DKROT.spells["Howling Blast"]
       end
 
-      --Obliterate when second Unholy Rune is nearly off cooldown
+      -- Obliterate when second Unholy Rune is nearly off cooldown
       if GetSpellTexture(DKROT.spells["Obliterate"])~=nil then
          if lunholy <= 2 and not ud and (frost <= 0 or blood <= 0) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Obliterate"])
-         end
-      else --Plague Strike
-         if unholy <= 0 then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
+            return DKROT.spells["Obliterate"]
          end
       end
 
-      --Howling Blast
+      -- Howling Blast
       if death >= 1 or frost <= 0 then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Howling Blast"])
+         return DKROT.spells["Howling Blast"]
       end
 
-      --Blood Tap with >= 5 Charges
+      -- Blood Tap with >= 5 Charges
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
          and (frost >= 0 or unholy >= 0 or blood >= 0)
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+         return DKROT.spells["Blood Tap"], true
       end
 
-      --Frost Strike
+      -- Frost Strike
       if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") > 39 then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Frost Strike"])
+         return DKROT.spells["Frost Strike"]
       end
 
-      --Empower Rune Weapon
+      -- Empower Rune Weapon if we have it enabled and we have at least 3 runes depleted
       if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
-      and DKROT_Settings.CD[DKROT.Current_Spec].ERW then
+         and DKROT_Settings.CD[DKROT.Current_Spec].ERW
+         and DKROT:DepletedRunes() >= 3
+      then
          if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Empower Rune Weapon"])
+            return DKROT.spells["Empower Rune Weapon"]
          end
       end
 
-      --If nothing else can be done
+      -- If nothing else can be done
       return nil
    end
 
-   DKROT:RegisterRotation(DKROT.SPECS.FROST, 'IcyVeins2H', 'Icy Veins - Twohand', IcyVeins2H)
-   DKROT:RegisterRotation(DKROT.SPECS.FROST, 'IcyVeinsDualWield', 'Icy Veins - Dual Wield', IcyVeinsDualWield)
-
-   -- Function to determine rotation for Frost Spec
-   function DKROT:FrostMove(icon)
-      if DKROT_Settings.CD[DKROT.Current_Spec].AltRot then
-         return DKROT.Rotations[DKROT.SPECS.FROST]["IcyVeinsDualWield"]["func"](icon)
+   local function SimC2H()
+      -- Rune Info
+      local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
+      local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+      local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
+      local death = DKROT:DeathRunes()
+      local dFF, dBP = DKROT:GetDiseaseTime()
+      local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
+ 
+      -- Death Pact
+      if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
+         and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
+      then
+         if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
+            return DKROT.spells["Death Pact"], true
+         end
       end
 
-      return DKROT.Rotations[DKROT.SPECS.FROST]["IcyVeins2H"]["func"](icon)
+      -- Plague Leech if we have enabled it in the rotation, and we have a fully depleted rune
+      if GetSpellTexture(DKROT.spells["Plague Leech"])
+         and DKROT:isOffCD(DKROT.spells["Plague Leech"])
+         and DKROT:HasFullyDepletedRunes()
+         and (dFF ~= nil and dBP ~= nil and dFF > 0 and dBP > 0)
+         and DKROT_Settings.CD[DKROT.Current_Spec].PL
+      then
+         return DKROT.spells["Plague Leech"]
+      end
+
+      -- Soul Reaper
+      if GetSpellTexture(DKROT.spells["Soul Reaper"]) ~= nil
+         and UnitHealth("target")/UnitHealthMax("target") < 0.35
+      then
+         if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
+            return DKROT.spells["Soul Reaper"]
+         end
+      end
+
+      -- Defile
+      if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
+         if DKROT:isOffCD(DKROT.spells["Defile"]) then
+            return DKROT.spells["Defile"]
+         end
+      end
+ 
+      -- Rime Howling Blast if we need to refresh
+      local rimeProc = select(7, UnitBuff("player", DKROT.spells["Freezing Fog"]))
+      if rimeProc ~= nil 
+         and (dFF == nil or dFF < 5)
+      then
+         return DKROT.spells["Howling Blast"]
+      end
+
+      -- Diseases
+      local disease = DKROT:GetDisease()
+      if disease ~= nil then
+         return disease
+      end
+
+      -- Breath of Sindragosa
+      if GetSpellTexture(DKROT.spells["Breath of Sindragosa"]) ~= nil and UnitPower("player") > 75 then
+         if DKROT:isOffCD(DKROT.spells["Breath of Sindragosa"]) then
+            return DKROT.spells["Breath of Sindragosa"]
+         end
+      end
+
+      -- Obliterate with killing machine or runes overcaped
+      if GetSpellTexture(DKROT.spells["Obliterate"]) ~= nil
+         and select(1,IsUsableSpell(DKROT.spells["Obliterate"]))
+         and (select(7,UnitBuff("player", DKROT.spells["Killing Machine"])) ~= nil
+         or (lfrost <= 0 or lunholy <= 0 or (lblood <= 0 and lbd)))
+      then
+         return DKROT.spells["Obliterate"]
+      end
+
+      -- Blood Tap with >= 11 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 11
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT.spells["Blood Tap"], true
+      end
+
+      -- Frost Strike if rp overcaped
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") > 76 then
+         return DKROT.spells["Frost Strike"]
+      end
+ 
+      -- Howling Blast if Rime is procced
+      if rimeProc ~= nil then
+         return DKROT.spells["Howling Blast"]
+      end
+
+      -- Obliterate
+      if GetSpellTexture(DKROT.spells["Obliterate"]) ~= nil then
+         if select(1,IsUsableSpell(DKROT.spells["Obliterate"])) then
+            return DKROT.spells["Obliterate"]
+         end
+      else
+         -- Howling Blast
+         if frost <= 0 then
+            return DKROT.spells["Howling Blast"]
+         end
+
+         --Plague Strike
+         if unholy <= 0 then
+            return DKROT.spells["Plague Strike"]
+         end
+      end
+
+      -- Frost Strike
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP and UnitPower("player") >= 25 then
+         return DKROT.spells["Frost Strike"]
+      end
+
+      -- Blood Tap with >= 5 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 5
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT.spells["Blood Tap"], true
+      end
+
+      -- Empower Rune Weapon if we have it enabled and we have at least 3 runes depleted
+      if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil
+         and DKROT_Settings.CD[DKROT.Current_Spec].ERW
+         and DKROT:DepletedRunes() >= 3
+      then
+         if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
+            return DKROT.spells["Empower Rune Weapon"]
+         end
+      end
+
+      -- If nothing else can be done
+      return nil
    end
+
+   DKROT_RegisterRotation(DKROT.SPECS.FROST, 'IcyVeins2H', '2H Frost - Icy Veins', IcyVeins2H, true)
+   DKROT_RegisterRotation(DKROT.SPECS.FROST, 'IcyVeinsDualWield', 'Dual Wield Frost - Icy Veins', IcyVeinsDualWield, false)
+   DKROT_RegisterRotation(DKROT.SPECS.FROST, 'SimC2H', '2H Frost - SimCraft', SimC2H, false)
 end

--- a/rotations/unholy.lua
+++ b/rotations/unholy.lua
@@ -1,0 +1,175 @@
+if select(2, UnitClass("player")) == "DEATHKNIGHT" then
+   local _, DKROT = ...
+
+   local function IcyVeins(icon)
+      if DKROT_Settings.CD[DKROT.Current_Spec].AltRot then
+         return DKROT:UnholyMoveAlt(icon)
+      end
+
+      --Rune Info
+      local frost, lfrost, fd, lfd = DKROT:RuneCDs(DKROT.SPECS.FROST)
+      local unholy, lunholy = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+      local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
+      local death = DKROT:DeathRunes()
+      local disease, move = DKROT:GetDisease(icon)
+      local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
+
+      -- Raise Dead
+      if GetSpellTexture(DKROT.spells["Raise Dead"]) ~= nil and UnitExists("pet") ~= true then
+         return GetSpellTexture(DKROT.spells["Raise Dead"])
+      end
+
+      -- Death Pact
+      if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
+         and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
+      then
+         if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
+            return GetSpellTexture(DKROT.spells["Death Pact"])
+         end
+      end
+
+      -- Soul Reaper
+      if GetSpellTexture(DKROT.spells["Soul Reaper"]) ~= nil and (death >= 1 or unholy <= 0)
+      then
+         if (
+               GetSpellTexture(DKROT.spells["Improved Soul Reaper"]) ~= nil
+               and UnitHealth("target")/UnitHealthMax("target") < 0.45
+            )
+            or UnitHealth("target")/UnitHealthMax("target") < 0.35
+         then
+            if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
+               return DKROT:GetRangeandIcon(icon, DKROT.spells["Soul Reaper"])
+            end
+         end
+      end
+
+      -- Defile
+      if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
+         if DKROT:isOffCD(DKROT.spells["Defile"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Defile"])
+         end
+      end
+
+      -- Diseases
+      if disease then return move end
+
+      -- Dark Transformation
+      if GetSpellTexture(DKROT.spells["Dark Transformation"]) ~= nil
+         and select(4, UnitBuff("PET",DKROT.spells["Shadow Infusion"])) == 5
+         and (unholy <= 0 or death >= 1)
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Dark Transformation"])
+      end
+
+      -- Blood Tap with >= 11 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 11
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+      end
+
+      -- Death Coil if ghoul is not transformed or have 5 stacks
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP
+         and (
+            UnitPower("player") >= 30
+            or select(7, UnitBuff("PLAYER",DKROT.spells["Sudden Doom"])) ~= nil
+         )
+         and select(4, UnitBuff("PET",DKROT.spells["Shadow Infusion"])) ~= 5
+         and UnitBuff("PET",DKROT.spells["Dark Transformation"]) == nil
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
+      end
+
+      --Scourge Strike (UU are up or FF or BB are up as Deathrunes)
+      if lunholy <= 0 or (lfrost <= 0 and (fd or lfd)) or (lblood <= 0 and (bd or lbd)) then
+         if DKROT_Settings.MoveAltDND then
+            --Death and Decay
+            if GetSpellTexture(DKROT.spells["Death and Decay"]) ~= nil then
+               if DKROT:isOffCD(DKROT.spells["Death and Decay"]) then
+                  DKROT.Move.AOE:SetAlpha(1)
+                  DKROT.Move.AOE.Icon:SetTexture(GetSpellTexture(DKROT.spells["Death and Decay"]))
+               end
+            end
+         end
+         if GetSpellTexture(DKROT.spells["Scourge Strike"]) ~= nil then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Scourge Strike"])
+         else
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
+         end
+      end
+
+      -- Festering Strike (BB and FF are up)
+      if GetSpellTexture(DKROT.spells["Festering Strike"]) ~= nil then
+         if lfrost <= 0 and lblood <= 0 then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Festering Strike"])
+         end
+      end
+
+      -- Death Coil (Sudden Doom, high RP)
+      if DKROT_Settings.CD[DKROT.Current_Spec].RP
+         and (
+            UnitPower("player") > 80
+            or select(7, UnitBuff("PLAYER",DKROT.spells["Sudden Doom"])) ~= nil
+         )
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
+      end
+
+      -- Scourge Strike
+      if unholy <= 0 or death >= 1 then
+         if DKROT_Settings.MoveAltDND then
+            --Death and Decay
+            if GetSpellTexture(DKROT.spells["Death and Decay"]) ~= nil then
+               if DKROT:isOffCD(DKROT.spells["Death and Decay"]) then
+                  DKROT.Move.AOE:SetAlpha(1)
+                  DKROT.Move.AOE.Icon:SetTexture(GetSpellTexture(DKROT.spells["Death and Decay"]))
+               end
+            end
+         end
+         if GetSpellTexture(DKROT.spells["Scourge Strike"]) ~= nil then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Scourge Strike"])
+         else
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
+         end
+      end
+
+      -- Festering Strike
+      if GetSpellTexture(DKROT.spells["Festering Strike"]) ~= nil then
+         if frost <= 0 and blood <= 0 then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Festering Strike"])
+         end
+      end
+
+      --Blood Tap with >= 5 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 5
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+      end
+
+      --Empower Rune Weapon
+      if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil and DKROT_Settings.CD[DKROT.Current_Spec].ERW then
+         if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
+            return DKROT:GetRangeandIcon(icon, DKROT.spells["Empower Rune Weapon"])
+         end
+      end
+
+      if GetSpellTexture(DKROT.spells["Death Coil"]) and UnitPower("player") >= 30 then
+         return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
+      end
+
+      -- If nothing else can be done
+      return nil
+   end
+
+   DKROT:RegisterRotation(DKROT.SPECS.UNHOLY, 'IcyVeins', 'Icy Veins', IcyVeins)
+
+   -- Function to determine rotation for Unholy Spec
+   function DKROT:UnholyMove(icon)
+      return DKROT.Rotations[DKROT.SPECS.UNHOLY]["IcyVeins"]["func"](icon)
+   end
+end

--- a/rotations/unholy.lua
+++ b/rotations/unholy.lua
@@ -1,22 +1,22 @@
 if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    local _, DKROT = ...
 
-   local function IcyVeins(icon)
-      if DKROT_Settings.CD[DKROT.Current_Spec].AltRot then
-         return DKROT:UnholyMoveAlt(icon)
-      end
-
-      --Rune Info
+   local function IcyVeins()
+      -- Rune Info
       local frost, lfrost, fd, lfd = DKROT:RuneCDs(DKROT.SPECS.FROST)
       local unholy, lunholy = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
       local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
       local death = DKROT:DeathRunes()
-      local disease, move = DKROT:GetDisease(icon)
       local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
+ 
+      -- Horn of Winter
+      if DKROT_Settings.UseHoW and DKROT:UseHoW() then
+         return DKROT.spells["Horn of Winter"]
+      end
 
       -- Raise Dead
-      if GetSpellTexture(DKROT.spells["Raise Dead"]) ~= nil and UnitExists("pet") ~= true then
-         return GetSpellTexture(DKROT.spells["Raise Dead"])
+      if UnitExists("pet") ~= true then
+         return DKROT.spells["Raise Dead"], true
       end
 
       -- Death Pact
@@ -24,41 +24,43 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
       then
          if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
-            return GetSpellTexture(DKROT.spells["Death Pact"])
+            return DKROT.spells["Death Pact"], true
          end
       end
 
       -- Soul Reaper
-      if GetSpellTexture(DKROT.spells["Soul Reaper"]) ~= nil and (death >= 1 or unholy <= 0)
+      if (
+            GetSpellTexture(DKROT.spells["Improved Soul Reaper"]) ~= nil
+            and UnitHealth("target")/UnitHealthMax("target") < 0.45
+         )
+         or UnitHealth("target")/UnitHealthMax("target") < 0.35
       then
-         if (
-               GetSpellTexture(DKROT.spells["Improved Soul Reaper"]) ~= nil
-               and UnitHealth("target")/UnitHealthMax("target") < 0.45
-            )
-            or UnitHealth("target")/UnitHealthMax("target") < 0.35
-         then
-            if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
-               return DKROT:GetRangeandIcon(icon, DKROT.spells["Soul Reaper"])
-            end
+         if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
+            return DKROT.spells["Soul Reaper"]
          end
       end
 
       -- Defile
       if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
          if DKROT:isOffCD(DKROT.spells["Defile"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Defile"])
+            return DKROT.spells["Defile"], true
          end
       end
 
       -- Diseases
-      if disease then return move end
+      local disease = DKROT:GetDisease()
+      if disease ~= nil then
+         return disease
+      end
 
       -- Dark Transformation
-      if GetSpellTexture(DKROT.spells["Dark Transformation"]) ~= nil
-         and select(4, UnitBuff("PET",DKROT.spells["Shadow Infusion"])) == 5
-         and (unholy <= 0 or death >= 1)
+      if select(4, UnitBuff("PET",DKROT.spells["Shadow Infusion"])) == 5
+         and (
+            GetSpellTexture(DKROT.spells["Enhanced Dark Transformation"]) ~= nil
+            or (unholy <= 0 or death >= 1)
+         )
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Dark Transformation"])
+         return DKROT.spells["Dark Transformation"]
       end
 
       -- Blood Tap with >= 11 Charges
@@ -67,7 +69,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          and bloodCharges ~= nil and bloodCharges >= 11
          and (frost >= 0 or unholy >= 0 or blood >= 0)
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+         return DKROT.spells["Blood Tap"], true
       end
 
       -- Death Coil if ghoul is not transformed or have 5 stacks
@@ -79,13 +81,13 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          and select(4, UnitBuff("PET",DKROT.spells["Shadow Infusion"])) ~= 5
          and UnitBuff("PET",DKROT.spells["Dark Transformation"]) == nil
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
+         return DKROT.spells["Death Coil"]
       end
 
-      --Scourge Strike (UU are up or FF or BB are up as Deathrunes)
+      -- Scourge Strike (UU are up or FF or BB are up as Deathrunes)
       if lunholy <= 0 or (lfrost <= 0 and (fd or lfd)) or (lblood <= 0 and (bd or lbd)) then
          if DKROT_Settings.MoveAltDND then
-            --Death and Decay
+            -- Death and Decay
             if GetSpellTexture(DKROT.spells["Death and Decay"]) ~= nil then
                if DKROT:isOffCD(DKROT.spells["Death and Decay"]) then
                   DKROT.Move.AOE:SetAlpha(1)
@@ -93,34 +95,29 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                end
             end
          end
-         if GetSpellTexture(DKROT.spells["Scourge Strike"]) ~= nil then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Scourge Strike"])
-         else
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
-         end
+
+         return DKROT.spells["Scourge Strike"]
       end
 
       -- Festering Strike (BB and FF are up)
-      if GetSpellTexture(DKROT.spells["Festering Strike"]) ~= nil then
-         if lfrost <= 0 and lblood <= 0 then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Festering Strike"])
-         end
+      if lfrost <= 0 and lblood <= 0 then
+         return DKROT.spells["Festering Strike"]
       end
 
       -- Death Coil (Sudden Doom, high RP)
       if DKROT_Settings.CD[DKROT.Current_Spec].RP
          and (
             UnitPower("player") > 80
-            or select(7, UnitBuff("PLAYER",DKROT.spells["Sudden Doom"])) ~= nil
+            or select(7, UnitBuff("PLAYER", DKROT.spells["Sudden Doom"])) ~= nil
          )
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
+         return DKROT.spells["Death Coil"]
       end
 
       -- Scourge Strike
       if unholy <= 0 or death >= 1 then
          if DKROT_Settings.MoveAltDND then
-            --Death and Decay
+            -- Death and Decay
             if GetSpellTexture(DKROT.spells["Death and Decay"]) ~= nil then
                if DKROT:isOffCD(DKROT.spells["Death and Decay"]) then
                   DKROT.Move.AOE:SetAlpha(1)
@@ -128,48 +125,195 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                end
             end
          end
-         if GetSpellTexture(DKROT.spells["Scourge Strike"]) ~= nil then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Scourge Strike"])
-         else
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Plague Strike"])
-         end
+
+         return DKROT.spells["Scourge Strike"]
       end
 
       -- Festering Strike
-      if GetSpellTexture(DKROT.spells["Festering Strike"]) ~= nil then
-         if frost <= 0 and blood <= 0 then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Festering Strike"])
-         end
+      if frost <= 0 and blood <= 0 then
+         return DKROT.spells["Festering Strike"]
       end
 
-      --Blood Tap with >= 5 Charges
+      -- Blood Tap with >= 5 Charges
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Blood Tap"])
+         return DKROT.spells["Blood Tap"], true
       end
 
-      --Empower Rune Weapon
+      -- Empower Rune Weapon
       if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil and DKROT_Settings.CD[DKROT.Current_Spec].ERW then
          if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
-            return DKROT:GetRangeandIcon(icon, DKROT.spells["Empower Rune Weapon"])
+            return DKROT.spells["Empower Rune Weapon"]
          end
       end
 
       if GetSpellTexture(DKROT.spells["Death Coil"]) and UnitPower("player") >= 30 then
-         return DKROT:GetRangeandIcon(icon, DKROT.spells["Death Coil"])
+         return DKROT.spells["Death Coil"]
       end
 
       -- If nothing else can be done
       return nil
    end
 
-   DKROT:RegisterRotation(DKROT.SPECS.UNHOLY, 'IcyVeins', 'Icy Veins', IcyVeins)
+   local function SimC()
+      -- Rune Info
+      local frost, lfrost, fd, lfd = DKROT:RuneCDs(DKROT.SPECS.FROST)
+      local unholy, lunholy = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+      local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
+      local death = DKROT:DeathRunes()
+      local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"]))
+      local dFF, dBP = DKROT:GetDiseaseTime()
+ 
+      -- Horn of Winter
+      if DKROT_Settings.UseHoW and DKROT:UseHoW() then
+         return DKROT.spells["Horn of Winter"]
+      end
 
-   -- Function to determine rotation for Unholy Spec
-   function DKROT:UnholyMove(icon)
-      return DKROT.Rotations[DKROT.SPECS.UNHOLY]["IcyVeins"]["func"](icon)
+      -- Raise Dead
+      if UnitExists("pet") ~= true then
+         return DKROT.spells["Raise Dead"], true
+      end
+
+      -- Death Pact
+      if GetSpellTexture(DKROT.spells["Death Pact"]) ~= nil
+         and (UnitHealth("player") / UnitHealthMax("player")) < 0.30
+      then
+         if DKROT:isOffCD(DKROT.spells["Death Pact"]) then
+            return DKROT.spells["Death Pact"], true
+         end
+      end
+
+      -- Plague Leech if we have enabled it in the rotation, and we have a fully depleted rune
+      if GetSpellTexture(DKROT.spells["Plague Leech"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].PL
+         and DKROT:isOffCD(DKROT.spells["Plague Leech"])
+         and DKROT:HasFullyDepletedRunes()
+         and (dFF ~= nil and dBP ~= nil and dFF > 0 and dBP > 0)
+      then
+         return DKROT.spells["Plague Leech"]
+      end
+
+      -- Soul Reaper
+      if (
+            GetSpellTexture(DKROT.spells["Improved Soul Reaper"]) ~= nil
+            and UnitHealth("target")/UnitHealthMax("target") < 0.45
+         )
+         or UnitHealth("target")/UnitHealthMax("target") < 0.35
+      then
+         if DKROT:isOffCD(DKROT.spells["Soul Reaper"]) then
+            return DKROT.spells["Soul Reaper"]
+         end
+      end
+
+      -- Defile
+      if GetSpellTexture(DKROT.spells["Defile"]) ~= nil then
+         if DKROT:isOffCD(DKROT.spells["Defile"]) then
+            return DKROT.spells["Defile"], true
+         end
+      end
+
+      -- Blood Tap with >= 11 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 11
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT.spells["Blood Tap"], true
+      end
+
+      -- Summon Gargoyle
+      if DKROT:isOffCD(DKROT.spells["Summon Gargoyle"]) then
+         return DKROT.spells["Summon Gargoyle"]
+      end
+
+      -- Death Coil if we are close to RP cap or with Sudden Doom proc
+      if UnitPower("player") > 90 or select(7, UnitBuff("PLAYER", DKROT.spells["Sudden Doom"])) then
+         return DKROT.spells["Death Coil"]
+      end
+
+      -- Dark Transformation
+      if select(4, UnitBuff("PET",DKROT.spells["Shadow Infusion"])) == 5
+         and (
+            GetSpellTexture(DKROT.spells["Enhanced Dark Transformation"]) ~= nil
+            or (unholy <= 0 or death >= 1)
+         )
+      then
+         return DKROT.spells["Dark Transformation"]
+      end
+
+      -- Diseases
+      local disease = DKROT:GetDisease()
+      if disease ~= nil then
+         return disease
+      end
+ 
+      -- Breath of Sindragosa
+      if GetSpellTexture(DKROT.spells["Breath of Sindragosa"]) ~= nil
+         and UnitPower("player") > 75 
+         and DKROT:isOffCD(DKROT.spells["Breath of Sindragosa"])
+      then
+         return DKROT.spells["Breath of Sindragosa"]
+      end
+
+      -- Blood Tap if both unholy runes are down
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 5
+         and (frost >= 0 or blood >= 0)
+      then
+         return DKROT.spells["Blood Tap"], true
+      end
+
+      if lunholy <= 0 and DKROT:isOffCD(DKROT.spells["Scourge Strike"]) then
+         return DKROT.spells["Scourge Strike"]
+      end
+
+      -- Death Coil if we have more than 80 RP
+      if UnitPower("player") >= 80 then
+         return DKROT.spells["Death Coil"]
+      end
+
+      -- Festering Strike if both blood and frost runes are up
+      if (lblood <= 0 and lfrost <= 0) then
+         return DKROT.spells["Festering Strike"]
+      end
+ 
+      -- Blood Tap with >= 5 Charges
+      if GetSpellTexture(DKROT.spells["Blood Tap"])
+         and DKROT_Settings.CD[DKROT.Current_Spec].BT
+         and bloodCharges ~= nil and bloodCharges >= 5
+         and (frost >= 0 or unholy >= 0 or blood >= 0)
+      then
+         return DKROT.spells["Blood Tap"], true
+      end
+
+      if DKROT:isOffCD(DKROT.spells["Scourge Strike"]) then
+         return DKROT.spells["Scourge Strike"]
+      end
+
+      if DKROT:isOffCD(DKROT.spells["Festering Strike"]) then
+         return DKROT.spells["Festering Strike"]
+      end
+
+      -- Death Coil if more than 30 RP
+      if UnitPower("player") >= 30 then
+         return DKROT.spells["Death Coil"]
+      end
+
+      -- Empower Rune Weapon
+      if GetSpellTexture(DKROT.spells["Empower Rune Weapon"]) ~= nil and DKROT_Settings.CD[DKROT.Current_Spec].ERW then
+         if DKROT:isOffCD(DKROT.spells["Empower Rune Weapon"]) then
+            return DKROT.spells["Empower Rune Weapon"]
+         end
+      end
+
+      -- If nothing else can be done
+      return nil
    end
+
+   DKROT_RegisterRotation(DKROT.SPECS.UNHOLY, 'IcyVeins', 'Unholy - Icy Veins', IcyVeins, true)
+   DKROT_RegisterRotation(DKROT.SPECS.UNHOLY, 'SimC', 'Unholy - SimCraft', SimC, false)
 end


### PR DESCRIPTION
* Did some major refactoring, breaking out the logic into multiple files.
    * Rotation functions are now in separate files, one per spec
    * Rotations can now be registered from external files as well, by calling DKROT_RegisterRotation(spec, internalName, rotationName, rotationFunction, defaultRotation)
* Rotations are now selected by a drop down instead of a binary Main or Alternate rotation, as there can be more than 2 rotations for a given spec
* Added support for tracking Horn of Winter buff, and re-applying it if it falls off. Won't ask you to refresh HoW if you have a similar buff from another source (another DK, hunter or warrior)
* DKROT is no longer registered in the global namespace, but instead uses the internal addonTable provided by WoW (the ... special variable)
* Added rotations based primarily on the action list from SimCraft. These are not default rotations, so you should manually go to the settings to change them if you want to use them