### PR TITLE
Improve Blood Tap detection

### DIFF
--- a/rotations/blank.lua
+++ b/rotations/blank.lua
@@ -34,7 +34,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 11
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end
@@ -71,7 +71,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end

--- a/rotations/blood.lua
+++ b/rotations/blood.lua
@@ -70,7 +70,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 11
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"]
       end
@@ -104,7 +104,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end
@@ -209,7 +209,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end

--- a/rotations/frost.lua
+++ b/rotations/frost.lua
@@ -65,7 +65,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 11
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end
@@ -106,7 +106,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end
@@ -175,7 +175,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 11
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end
@@ -234,7 +234,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end
@@ -336,7 +336,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 11
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end
@@ -377,7 +377,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end

--- a/rotations/unholy.lua
+++ b/rotations/unholy.lua
@@ -67,7 +67,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 11
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end
@@ -219,7 +219,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 11
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end
@@ -262,7 +262,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
-         and (frost >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end
@@ -285,7 +285,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       if GetSpellTexture(DKROT.spells["Blood Tap"])
          and DKROT_Settings.CD[DKROT.Current_Spec].BT
          and bloodCharges ~= nil and bloodCharges >= 5
-         and (frost >= 0 or unholy >= 0 or blood >= 0)
+         and DKROT:HasFullyDepletedRunes()
       then
          return DKROT.spells["Blood Tap"], true
       end


### PR DESCRIPTION
Improve Blood Tap detection to not fire unless we have a truely fully depleted rune