### PR TITLE
Necroblight cleanup, scaling tweak and BoS added to CDT

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -142,6 +142,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          TalentCDs ={
             DKROT.spells["Anti-Magic Zone"],
             DKROT.spells["Asphyxiate"],
+            DKROT.spells["Breath of Sindragosa"],
             DKROT.spells["Conversion"],
             DKROT.spells["Death's Advance"],
             DKROT.spells["Death Pact"],
@@ -180,6 +181,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             [DKROT.spells["Anti-Magic Shell"]] = {"player", true},
             [DKROT.spells["Asphyxiate"]] = {"target", true},
             [DKROT.spells["Blood Charge"]] = {"player", false},
+            [DKROT.spells["Breath of Sindragosa"]] = {"player", true},
             [DKROT.spells["Chilblains"]] = {"target", false},
             [DKROT.spells["Conversion"]] = {"player", false},
             [DKROT.spells["Dark Succor"]] = {"player", false},

--- a/rotations/unholy.lua
+++ b/rotations/unholy.lua
@@ -477,8 +477,10 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          if DKROT:isOffCD("Festering Strike") and DKROT:HasTalent("Necrotic Plague") and DKROT:HasTalent("Unholy Blight") then
             local ubcd = DKROT:GetCD("Unholy Blight")
 
-            if dFF < ubcd and ((dFF < 20) or not (bd and fd)) then
-               return "Festering Strike"
+            if dFF < ubcd and ((dFF < 20) or not (bd or fd)) then
+               if timeToDie == nil or timeToDie > dFF then
+                  return "Festering Strike"
+               end
             end
          end
 

--- a/ui.lua
+++ b/ui.lua
@@ -274,7 +274,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             value = 1.0,
             label = DKROT_OPTIONS_POSITION_SCALE,
             minValue = 0.5,
-            maxValue = 1.5,
+            maxValue = 5.0,
          },
          opacity = {
             parent = DKROT_PositionPanel,


### PR DESCRIPTION
* Allow scaling UI elements up to 5x now instead of 1.5 x
* Add Breath of Sindragosa to Cooldown tracker
* Reduce Festering Strikes for Necroblight. Never FeS if target will die before diseases fall off