### PR TITLE
Frost Rotation updates

### DIFF
--- a/Localization/localization.lua
+++ b/Localization/localization.lua
@@ -105,7 +105,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    DKROT_ABOUT = "About"
    DKROT_ABOUT_BODY = "DKRot was initially forked from the CLC DK addon on Nov. 28 2014. CLC DK author did a great job building an awesome addon, but I felt the development had stagnated so I decided to fork the addon and start implementing features I've been missing in the addon.<br /><br />If you have any issues, comments or other feedback, please head on over to http://www.curse.com/addons/wow/dkrot and leave a comment"
    DKROT_ABOUT_ROTATION_INFO = "Rotations in this addon is based mainly on the work of Skullflower (Unholy and Frost) and Troxism (Blood), based on the information available on http://summonstone.com/"
-   DKROT_ABOUT_AUTHOR = "Author: Jardo US-Hyjal (WoD)"
+   DKROT_ABOUT_AUTHOR = "Author: Jardo US-Kilrogg (WoD)"
    DKROT_ABOUT_VERSION = "Version: " .. GetAddOnMetadata("DKRot", "Version")
    DKROT_OPTIONS_EXPORT = "Bug Report Export"
 end

--- a/data.lua
+++ b/data.lua
@@ -64,9 +64,11 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          -- Frost Only
          ["Freezing Fog"] = GetSpellInfo(59052), -- lvl70
          ["Frost Strike"] = GetSpellInfo(49143),
+         ["Frozen Wake"] = GetSpellInfo(187894), -- tier18 2p crit damage buff
          ["Howling Blast"] = GetSpellInfo(49184),
          ["Killing Machine"] = GetSpellInfo(51124), -- lvl63
          ["Obliterate"] = GetSpellInfo(49020), -- lvl58
+         ["Obliteration"] = GetSpellInfo(187893), -- tier18 2p haste buff
          ["Pillar of Frost"] = GetSpellInfo(51271), -- lvl68
 
          -- Unholy Only
@@ -81,27 +83,27 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          ["Summon Gargoyle"] = GetSpellInfo(49206), -- lvl74
 
          -- Racials
-         ["Human"] = GetSpellInfo(59752),-- Every Man for Himself
-         ["Dwarf"] = GetSpellInfo(20594),-- Stoneform
-         ["NightElf"] = GetSpellInfo(58984),-- Shadowmeld
-         ["Gnome"] = GetSpellInfo(20589),-- Escape Artist
          ["Draenei"] = GetSpellInfo(28880),-- Gift of the Naaru
+         ["Dwarf"] = GetSpellInfo(20594),-- Stoneform
+         ["Gnome"] = GetSpellInfo(20589),-- Escape Artist
+         ["Human"] = GetSpellInfo(59752),-- Every Man for Himself
+         ["NightElf"] = GetSpellInfo(58984),-- Shadowmeld
          ["Worgen"] = GetSpellInfo(68992),-- Darkflight
 
+         ["BloodElf"] = GetSpellInfo(28730),-- Arcane Torrent
+         ["Goblin"] = GetSpellInfo(69070),-- Rocket Jump
          ["Orc"] = GetSpellInfo(33697),-- Blood Fury
          ["Scourge"] = GetSpellInfo(7744),-- Will of the Forsaken
          ["Tauren"] = GetSpellInfo(20549),-- War Stomp
          ["Troll"] = GetSpellInfo(26297),-- Berserking
-         ["BloodElf"] = GetSpellInfo(28730),-- Arcane Torrent
-         ["Goblin"] = GetSpellInfo(69070),-- Rocket Jump
 
          -- Other
-         ["Draenic Strength Potion"] = GetSpellInfo(156579),
-         ["Bloodlust"] = GetSpellInfo(2825),
-         ["Heroism"] = GetSpellInfo(32182),
-         ["Time Warp"] = GetSpellInfo(145534),
          ["Ancient Hysteria"] = GetSpellInfo(90355),
+         ["Bloodlust"] = GetSpellInfo(2825),
+         ["Draenic Strength Potion"] = GetSpellInfo(156579),
+         ["Heroism"] = GetSpellInfo(32182),
          ["Sated"] = GetSpellInfo(57724),
+         ["Time Warp"] = GetSpellInfo(145534),
       }
 
       DKROT.DTspells = { -- ID, Duration, Effected by talent
@@ -167,7 +169,9 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          },
          FrostCDs = {
             DKROT.spells["Freezing Fog"],
+            DKROT.spells["Frozen Wake"],
             DKROT.spells["Killing Machine"],
+            DKROT.spells["Obliteration"],
             DKROT.spells["Pillar of Frost"],
          },
          UnholyCDs = {
@@ -188,9 +192,11 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             [DKROT.spells["Dark Succor"]] = {"player", false},
             [DKROT.spells["Dark Simulacrum"]] = {"target", true},
             [DKROT.spells["Death's Advance"]] = {"player", true},
+            [DKROT.spells["Frozen Wake"]] = {"player", false},
             [DKROT.spells["Horn of Winter"]] = {"player", true},
             [DKROT.spells["Icebound Fortitude"]] = {"player", true},
             [DKROT.spells["Lichborne"]] = {"player", true},
+            [DKROT.spells["Obliteration"]] = {"player", false},
             [DKROT.spells["Remorseless Winter"]] = {"player", true},
             [DKROT.spells["Remorseless Winter"]] = {"target", true},
             [DKROT.spells["Runic Corruption"]] = {"player", false},

--- a/rotations/frost.lua
+++ b/rotations/frost.lua
@@ -1,228 +1,7 @@
--- vim: set ts=3 sw=3 foldmethod=indent
+-- vim: set ts=3 sw=3 foldmethod=indent:
 if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    local _, DKROT = ...
    
-   local function dw_def_tier18_4p()
-      -- Rune Info
-      local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
-      local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
-      local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
-      local death, tdeath = DKROT:DeathRunes()
-      local dFF, dBP = DKROT:GetDiseaseTime()
-      local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"])) or 0
-      local rimeProc = select(7, UnitBuff("player", DKROT.spells["Freezing Fog"]))
-      local kmProc = select(7, UnitBuff("player", DKROT.spells["Killing Machine"]))
-      local rp = UnitPower("PLAYER")
- 
-      -- Horn of Winter
-      if DKROT_Settings.CD[DKROT.Current_Spec].UseHoW and DKROT:UseHoW() then
-         return "Horn of Winter"
-      end
-
-      -- Pillar of Frost on CD
-      if DKROT:CanUse("Pillar of Frost") and DKROT:isOffCD("Pillar of Frost") then
-         if DKROT:BossOrPlayer("TARGET") then
-            return "Pillar of Frost"
-         end
-      end
-
-      -- Soul Reaper
-      if DKROT:CanUse("Soul Reaper") and DKROT:CanSoulReaper() then
-         return "Soul Reaper"
-      end
-
-      -- Blood Tap if we have more than 10 stacks
-      if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 and (frost > 0 and death < 1) and DKROT:CanSoulReaper(true) then
-          return "Blood Tap"
-      end
-
-      -- Frost Strike with Killing Machine
-      if kmProc and rp >= 25 then
-         return "Frost Strike"
-      end
-
-      -- Obliterate if we have an unholy rune
-      if DKROT:isOffCD("Obliterate") or kmProc then
-          return "Obliterate"
-      end
-
-      -- Defile
-      if DKROT:isOffCD("Defile") then
-          return "Defile"
-      end
-
-      -- Blood Tap
-      if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 and not DKROT:isOffCD("Defile") then
-          return "Blood Tap"
-      end
-
-      -- Frost Strike with Killing Machine or Runic Power is above 88
-      if rp >= 88 then
-         return "Frost Strike"
-      end
-
-      -- Howling Blast if we have either a death or a frost rune, or Rime is procced
-      if DKROT:isOffCD("Howling Blast") and ((death == 0 or frost == 0) or rimeProc) then
-          return "Howling Blast"
-      end
-
-      -- Blood Tap if we have over 10 charges and depleted runes
-      if DKROT:CanUse("Blood Tap") and bloodCharges >= 10 and DKROT:FullyDepletedRunes() > 0 then
-          return "Blood Tap"
-      end
-
-      -- Frost Strike with Killing Machine or Runic Power is above 76
-      if rp >= 76 then
-         return "Frost Strike"
-      end
-
-      -- Outbreak if we are missing blood plague
-      if DKROT:CanUse("Outbreak") and dBP == 0 and DKROT:isOffCD("Outbreak") then
-          return "Outbreak"
-      end
-
-      -- Plague Strike if we're missing blood plague
-      if DKROT:isOffCD("Plague Strike") and dBP == 0 then
-         return "Plague Strike"
-      end
-
-      -- Howling Blast if we have 2 or more death+frost runes
-      if death >= 2 or lfrost == 0 or (death == 1 and frost == 0) then
-          return "Howling Blast"
-      end
-
-      -- Blood Tap if we have enough charges and depleted runes
-      if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 and DKROT:FullyDepletedRunes() > 0 then
-          return "Blood Tap"
-      end
-
-      -- Plague Leech when we have a fully depleted rune
-      if DKROT:CanUse("Plague Leech") and DKROT:isOffCD("Plague Leech") and DKROT:FullyDepletedRunes() >= 2 and dFF > 0 and dBP > 0 then
-         return "Plague Leech"
-      end
-
-      -- Empower Rune Weapon if all runes are depleted and we are out of RP
-      if DKROT:CanUse("Empower Rune Weapon") and rp < 25 and DKROT:DepletedRunes() == 6 then
-         if DKROT:isOffCD("Empower Rune Weapon") and DKROT:BossOrPlayer("TARGET") then
-            return "Empower Rune Weapon"
-         end
-      end
-
-      -- If nothing else can be done
-      return nil
-   end
-
-   local function dw_def()
-      -- Rune Info
-      local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
-      local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
-      local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
-      local death, tdeath = DKROT:DeathRunes()
-      local dFF, dBP = DKROT:GetDiseaseTime()
-      local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"])) or 0
-      local rimeProc = select(7, UnitBuff("player", DKROT.spells["Freezing Fog"]))
-      local kmProc = select(7, UnitBuff("player", DKROT.spells["Killing Machine"]))
-      local rp = UnitPower("PLAYER")
- 
-      -- Horn of Winter
-      if DKROT_Settings.CD[DKROT.Current_Spec].UseHoW and DKROT:UseHoW() then
-         return "Horn of Winter"
-      end
-
-      -- Pillar of Frost on CD
-      if DKROT:CanUse("Pillar of Frost") and DKROT:isOffCD("Pillar of Frost") then
-         if DKROT:BossOrPlayer("TARGET") then
-            return "Pillar of Frost"
-         end
-      end
-
-      -- Blood Tap with 10 or more charges and RP over 76 or rp over 20 with KM proc
-      if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 and (rp >= 76 or (rp >= 20 and kmProc))  then
-         return "Blood Tap"
-      end
-
-      -- Soul Reaper
-      if DKROT:CanUse("Soul Reaper") and DKROT:CanSoulReaper() then
-         return "Soul Reaper"
-      end
-
-      -- Blood Tap if we have more than 10 stacks
-      if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 and (frost > 0 and death < 1) and DKROT:CanSoulReaper(true) then
-          return "Blood Tap"
-      end
-
-      -- Defile 
-      if DKROT:isOffCD("Defile") then
-          return "Defile"
-      end
-
-      -- Blood Tap if needed for defile
-      if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 and not DKROT:isOffCD("Defile") then
-          return "Blood Tap"
-      end
-
-      -- Frost Strike with Killing Machine and over 88 RP
-      if kmProc and rp >= 88 then
-         return "Frost Strike"
-      end
-
-      -- Howling Blast if we have a death or frost rune or missing frost fever
-      if (death >= 1 or frost == 0) or dFF == 0 then
-          return "Howling Blast"
-      end
-
-      -- Plague Strike if blood plague is missing
-      if dBP == 0 and DKROT:isOffCD("Plague Strike") then
-          return "Plague Strike"
-      end
-
-      -- Howling Blast if Rime is active
-      if rimeProc and DKROT:isOffCD("Howling Blast") then
-          return "Howling Blast"
-      end
-
-      -- Frost Strike if we have Tier17 2p bonus and runic power is over 50
-      -- and there's less than 5 seconds left on Piller of Frost CD
-      if DKROT:TierBonus(DKROT.Tiers.TIER17_2p) and rp >= 50 and DKROT:GetCD("Pillar of Frost") < 5 then
-          return "Frost Strike"
-      end
-
-      -- Frost Strike if we have more than 76 RP
-      if rp >= 76 then
-          return "Frost Strike"
-      end
-
-      -- Obliterate if we have an unholy rune and Killing Machine is NOT up
-      if DKROT:isOffCD("Obliterate") and not kmProc then
-          return "Obliterate"
-      end
-
-      -- Howling Blast if death + frost runes combined is more than 2 runes
-      if death >= 2 or lfrost == 0 or (death == 1 and frost == 0) then
-          return "Howling Blast"
-      end
-
-      -- Blood Tap
-      if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 then
-          return "Blood Tap"
-      end
-
-      -- Plague Leech when we have a fully depleted rune
-      if DKROT:CanUse("Plague Leech") and DKROT:isOffCD("Plague Leech") and DKROT:FullyDepletedRunes() >= 2 and dFF > 0 and dBP > 0 then
-         return "Plague Leech"
-      end
-
-      -- Empower Rune Weapon if all runes are depleted and we are out of RP
-      if DKROT:CanUse("Empower Rune Weapon") and rp < 25 and DKROT:DepletedRunes() == 6 then
-         if DKROT:isOffCD("Empower Rune Weapon") and DKROT:BossOrPlayer("TARGET") then
-            return "Empower Rune Weapon"
-         end
-      end
-
-      -- If nothing else can be done
-      return nil
-   end
-
    local twohand = {
       Name = "Two-Hand",
       InternalName = "FROST2H",
@@ -240,6 +19,8 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          local rimeProc = select(7, UnitBuff("player", DKROT.spells["Freezing Fog"]))
          local kmProc = select(7, UnitBuff("player", DKROT.spells["Killing Machine"]))
          local rp = UnitPower("PLAYER")
+         local oblitProc = select(7, UnitBuff("player", DKROT.spells["Obliteration"]))
+         local rp = UnitPower("PLAYER")
     
          -- Horn of Winter
          if DKROT_Settings.CD[DKROT.Current_Spec].UseHoW and DKROT:UseHoW() then
@@ -256,9 +37,8 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
          -- Plague Leech when we have two runes to return
          if DKROT:CanUse("Plague Leech") 
             and DKROT:isOffCD("Plague Leech") 
-            and DKROT:FullyDepletedRunes() > 0
-            and dFF > 0 
-            and dBP > 0
+            and DKROT:FullyDepletedRunes() >= 2
+            and ((dFF > 0 and dBP > 0) or (DKROT:GetCD("Outbreak") < 1))
          then
             return "Plague Leech"
          end
@@ -268,126 +48,56 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             return "Soul Reaper"
          end
 
-         -- Blood Tap if we need runes for Soul Reaper
-         if DKROT:CanUse("Blood Tap") and DKROT:CanUse("Soul Reaper") and DKROT:CanSoulReaper(true) and bloodCharges >= 5 then
-            return "Blood Tap"
-         end
-
          -- Defile
          if DKROT:CanUse("Defile") and DKROT:isOffCD("Defile") then
             return "Defile"
          end
 
-         -- Howling Blast with Rime and Killing Machine procs
-         if rimeProc and kmProc and (dBP > 5 or dFF > 5) then
+         -- Howling Blast if Rime is procced
+         if rimeProc and DKROT:isOffCD("Howling Blast") then
             return "Howling Blast"
          end
 
-         -- Obliterate with KM proc
-         if kmProc and DKROT:isOffCD("Obliterate") then
+         -- Obliterate if Killing Machine is procced or Unholy runes are capped
+         if DKROT:isOffCD("Obliterate") and (kmProc or lunholy < 0.5) then
             return "Obliterate"
          end
 
-         -- Blood Tap if KM proc is up and we have depleted runes
-         if DKROT:CanUse("Blood Tap") and kmProc and bloodCharges >= 5 and DKROT:FullyDepletedRunes() > 0 then
+         -- Blood Tap if we need runes for Soul Reaper
+         if DKROT:CanUse("Blood Tap") and DKROT:CanUse("Soul Reaper")
+            and DKROT:CanSoulReaper(true) and bloodCharges >= 5
+            and DKROT:FullyDepletedRunes() >= 1
+         then
             return "Blood Tap"
          end
 
-         -- Howling Blast if we're missing Frost Fever and Rime is procced
-         if DKROT:isOffCD("Howling Blast") and dFF == 0 and rimeProc then
-            return "Howling Blast"
-         end
-
-         -- Outbreak if we're missing both diseases
-         if DKROT:CanUse("Outbreak") and DKROT:isOffCD("Outbreak") and dFF == 0 and dBP == 0 then
+         -- Outbreak if we are missing a disease
+         if DKROT:CanUse("Outbreak") and DKROT:isOffCD("Outbreak") and (dFF == 0 or dBP == 0) then
             return "Outbreak"
          end
 
-         -- Howling Blast if Frost Fever is missing
-         if DKROT:isOffCD("Howling Blast") and dFF == 0 then
-            return "Howling Blast"
-         end
-
-         -- Plague Strike if Blood Plague is missing
+         -- Plague Strike if we're missing Blood Plague
          if DKROT:isOffCD("Plague Strike") and dBP == 0 then
             return "Plague Strike"
          end
 
-         -- Blood Tap if we have more than 10 charges and high RP
-         if DKROT:CanUse("Blood Tap") and bloodCharges >= 10 and rp > 76 then
-            return "Blood Tap"
-         end
-
-         -- Frost Strike when we have more than 76 RP
-         if rp > 76 then
-            return "Frost Strike"
-         end
-
-         -- Howling Blast if Rime is up and we are close to capping runes
-         if DKROT:isOffCD("Howling Blast") and rimeProc and (lblood <= 2 or lfrost <= 2 or lunholy <= 2) then
+         -- Howling Blast if we're missing Frost Fever
+         if kmProc and DKROT:isOffCD("Howling Blast") and dFF == 0 then
             return "Howling Blast"
          end
 
-         -- Obliterate if we are about to cap runes
-         if DKROT:isOffCD("Obliterate") and (lblood <= 2 or lfrost <= 2 or lunholy <= 2) then
-            return "Obliterate"
-         end
-
-         -- Plague Leech if rune pairs are about to become ready and diseases are about to drop
-         if DKROT:CanUse("Plague Leech")
-            and DKROT:isOffCD("Plague Leech")
-            and (dFF < 3 or dBP < 3)
-            and DKROT:FullyDepletedRunes() > 0
-            and (
-               (blood <= 1 and unholy <= 1)
-               or (frost <= 1 and unholy <= 1)
-               or (blood <= 1 and unholy <= 1)
-            )
-         then
-            return "Plague Leech"
-         end 
-
-         -- Frost Strike if we wont overcap blood charges and Obliterate is not about to be ready
-         if rp >= 25 and bloodCharges <= 10 and DKROT:GetCD("Obliterate") <= 1 then
+         -- Frost Strike if RP is over 75
+         if rp >= 75 then
             return "Frost Strike"
          end
 
-         -- Howling Blast if Rime is procced
-         if DKROT:isOffCD("Howling Blast") and rimeProc then
-            return "Howling Blast"
-         end
-
-         -- Obliterate if we are close to capping runes or Bloodlust is up
-         if DKROT:isOffCD("Obliterate")
-            and (
-               DKROT:BloodlustActive()
-               or lblood <= 3.5
-               or lfrost <= 3.5
-               or lunholy <= 3.5
-               or DKROT:GetCD("Plague Leech") <= 4
-            )
-         then
+         -- Obliterate if runes are capped
+         if lunholy < 0.5 or lfrost < 0.5 or lblood < 0.5 then
             return "Obliterate"
          end
 
-         -- Blood Tap if we have more than 10 stacks and 20 RP, or some runes are about to cap
-         if DKROT:CanUse("Blood Tap")
-            and DKROT:FullyDepletedRunes() > 0
-            and bloodCharges >= 5
-            and (
-               (bloodCharges >= 10 and rp >= 20)
-               or (
-                  lblood >= 3
-                  or lfrost >= 3
-                  or lunholy >= 3
-               )
-            )
-         then
-            return "Blood Tap"
-         end
-
-         -- Frost Strike if possible, without KM
-         if rp >= 25 and not kmProc then
+         -- Frost Strike with KM is NOT active and RP is over 25
+         if not kmProc and rp >= 25 then
             return "Frost Strike"
          end
 
@@ -497,17 +207,118 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    }
 
    local dw_def = {
-      Name = "DW - Defile",
+      Name = "Dual Wield",
       InternalName = "FROSTDWDEF",
       ToggleSpells = { "Pillar of Frost", "Plague Leech", "Soul Reaper", "Defile", "Outbreak", "Blood Tap", "Empower Rune Weapon", "Army of the Dead" },
       SuggestedTalents = { "Plague Leech", "Defile", "Blood Tap" },
       DefaultRotation = false,
       MainRotation = function()
-         if DKROT:TierBonus(DKROT.Tiers.TIER18_4p) then
-            return dw_def_tier18_4p()
-         else
-            return dw_def()
+         -- Rune Info
+         local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
+         local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
+         local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
+         local death, tdeath = DKROT:DeathRunes()
+         local dFF, dBP = DKROT:GetDiseaseTime()
+         local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"])) or 0
+         local rimeProc = select(7, UnitBuff("player", DKROT.spells["Freezing Fog"]))
+         local kmProc = select(7, UnitBuff("player", DKROT.spells["Killing Machine"]))
+         local wakeProc = select(7, UnitBuff("player", DKROT.spells["Frozen Wake"]))
+         local oblitProc = select(7, UnitBuff("player", DKROT.spells["Obliteration"]))
+         local rp = UnitPower("PLAYER")
+    
+         -- Horn of Winter
+         if DKROT_Settings.CD[DKROT.Current_Spec].UseHoW and DKROT:UseHoW() then
+            return "Horn of Winter"
          end
+
+         -- Pillar of Frost on CD
+         if DKROT:CanUse("Pillar of Frost") and DKROT:isOffCD("Pillar of Frost") then
+            if DKROT:BossOrPlayer("TARGET") then
+               return "Pillar of Frost"
+            end
+         end
+
+         -- Blood Tap with 10 or more charges and RP over 76 or rp over 20 with KM proc
+         if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 and (rp >= 76 or (rp >= 20 and kmProc))  then
+            return "Blood Tap"
+         end
+
+         -- Soul Reaper
+         if DKROT:CanUse("Soul Reaper") and DKROT:CanSoulReaper() then
+            return "Soul Reaper"
+         end
+
+         -- Defile 
+         if DKROT:isOffCD("Defile") then
+             return "Defile"
+         end
+
+         -- Blood Tap if needed for defile
+         if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 and not DKROT:isOffCD("Defile") then
+             return "Blood Tap"
+         end
+
+         -- Obliterate if Killing machine is active and we dont have enough RP for
+         -- Frost Strike, Unholy Runes are capped or Obliteration buff is missing
+         if DKROT:isOffCD("Obliterate") or DKROT:GetCD("Obliterate") < 1 then
+            if kmProc or rp < 25 or lunholy < 0.5 or (DKROT:TierBonus(DKROT.Tiers.TIER18_2p) and not oblitProc) then
+               return "Obliterate"
+            end
+         end
+
+         -- Frost Strike with Killing Machine and over 88 RP
+         if kmProc or rp >= 88 then
+            return "Frost Strike"
+         end
+
+         -- Howling Blast if frost and death runes are capped or Rime is procced
+         if (death >= 1 or lfrost < 0.5) or rimeProc then
+             return "Howling Blast"
+         end
+
+         -- Blood Tap if we have more than 10 stacks
+         if DKROT:CanUse("Blood Tap") 
+            and bloodCharges >= 5 and (frost > 0 and death < 1) 
+            and DKROT:CanSoulReaper(true) and DKROT:FullyDepletedRunes() > 1
+         then
+             return "Blood Tap"
+         end
+
+         -- Outbreak if either disease is missing
+         if DKROT:CanUse("Outbreak") and DKROT:isOffCD("Outbreak") and (dFF == 0 or dBP == 0) then
+            return "Outbreak"
+         end
+
+         -- Plague Strike if blood plague is missing
+         if dBP == 0 and DKROT:isOffCD("Plague Strike") then
+             return "Plague Strike"
+         end
+
+         -- Howling Blast if we have a death or Frost rune up
+         if death >= 1 or frost == 0 then
+             return "Howling Blast"
+         end
+
+         -- Frost Strike if we have Tier17 2p bonus and runic power is over 50
+         -- and there's less than 5 seconds left on Piller of Frost CD
+         if DKROT:TierBonus(DKROT.Tiers.TIER17_2p) and rp >= 50 and DKROT:GetCD("Pillar of Frost") < 5 then
+             return "Frost Strike"
+         end
+
+         -- Frost Strike if we have more than 25 RP
+         if rp >= 25 then
+             return "Frost Strike"
+         end
+
+         -- Empower Rune Weapon if all runes are depleted and we are out of RP
+         if DKROT:CanUse("Empower Rune Weapon") and rp < 25 and DKROT:DepletedRunes() == 6 then
+            if DKROT:isOffCD("Empower Rune Weapon") and DKROT:BossOrPlayer("TARGET") then
+               return "Empower Rune Weapon"
+            end
+         end
+
+         -- If nothing else can be done
+         return nil
       end,
       AOERotation = function()
          -- Rune Info
@@ -526,7 +337,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
             return "Horn of Winter"
          end
 
-         -- Pillar of Frost on CD
+         -- Pllar of Frost on CD
          if DKROT:CanUse("Pillar of Frost") and DKROT:isOffCD("Pillar of Frost") then
             if DKROT:BossOrPlayer("TARGET") then
                return "Pillar of Frost"
@@ -605,223 +416,8 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
    }
 
-   local dw_np = {
-      Name = "DW - Necrotic Plague",
-      InternalName = "FROSTDWNP",
-      ToggleSpells = { "Pillar of Frost", "Soul Reaper", "Outbreak", "Blood Tap", "Empower Rune Weapon", "Army of the Dead", "Plague Leech" },
-      SuggestedTalents = { "Plague Leech", "Necrotic Plague", "Blood Tap" },
-      DefaultRotation = false,
-      MainRotation = function()
-         -- Rune Info
-         local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
-         local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
-         local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
-         local death, tdeath = DKROT:DeathRunes()
-         local dFF, dBP = DKROT:GetDiseaseTime()
-         local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"])) or 0
-         local rimeProc = select(7, UnitBuff("player", DKROT.spells["Freezing Fog"]))
-         local kmProc = select(7, UnitBuff("player", DKROT.spells["Killing Machine"]))
-         local rp = UnitPower("PLAYER")
-         local npStacks = select(4, UnitDebuff("TARGET", DKROT.spells["Necrotic Plague"])) or 0
-    
-         -- Horn of Winter
-         if DKROT_Settings.CD[DKROT.Current_Spec].UseHoW and DKROT:UseHoW() then
-            return "Horn of Winter"
-         end
-
-         -- Pillar of Frost on CD
-         if DKROT:CanUse("Pillar of Frost") and DKROT:isOffCD("Pillar of Frost") then
-            if DKROT:BossOrPlayer("TARGET") then
-               return "Pillar of Frost"
-            end
-         end
-
-         -- Plague Leech if we have two or more runes depleted or Outbreak is about to come up
-         if DKROT:CanUse("Plague Leech") and DKROT:isOffCD("Plague Leech")
-            and dBP >= 0 and DKROT:FullyDepletedRunes() > 0 and (
-               DKROT:FullyDepletedRunes() >= 2 or dBP < 3 or DKROT:GetCD("Outbreak") < 1.5
-            )
-         then
-             return "Plague Leech"
-         end
-
-         -- Soul Reaper
-         if DKROT:CanUse("Soul Reaper") and DKROT:CanSoulReaper() then
-            return "Soul Reaper"
-         end
-
-         -- Blood Tap if needed for Soul Reaper
-         if DKROT:CanUse("Blood Tap") and bloodCharges >= 5
-            and DKROT:CanSoulReaper() and not DKROT:isOffCD("Soul Reaper")
-            and DKROT:FullyDepletedRunes() > 0
-         then
-            return "Blood Tap"
-         end
-
-         -- Frost Strike if Killing Machine is up
-         if rp >= 25 and kmProc then
-            return "Frost Strike"
-         end
-
-         -- Obliterate if we have at least one full unholy rune or Killing Machine is up
-         if DKROT:isOffCD("Obliterate") and (unholy == 0 or kmProc) then
-            return "Obliterate"
-         end
-
-         -- Frost Strike if we have more than 88 RP
-         if rp >= 88 then
-            return "Frost Strike"
-         end
-
-         -- Howling Blast if we have a death or frost rune, or Rime is up
-         if (death >= 1 or frost == 0) or rimeProc then
-            return "Howling Blast"
-         end
-
-         -- Blood Tap if we have more than 10 charges
-         if DKROT:CanUse("Blood Tap") and bloodCharges >= 10 and DKROT:FullyDepletedRunes() > 0 then
-            return "Blood Tap"
-         end
-
-         -- Frost Strike if we have more than 76 RP
-         if rp >= 76 then
-            return "Frost Strike"
-         end
-
-         -- Outbreak if necrotic plague isnt ticking
-         if npStacks == 0 and DKROT:CanUse("Outbreak") and DKROT:isOffCD("Outbreak") then
-             return "Outbreak"
-         end
-
-         -- Plague Strike if necrotic plague isnt ticking
-         if npStacks == 0 and DKROT:isOffCD("Plague Strike") then
-             return "Plague Strike"
-         end
-
-         -- Howling Blast if death + frost runes combines to more than 2 runes
-         if death >= 2 or lfrost == 0 or (death == 1 and frost == 0) then
-            return "Howling Blast"
-         end
-
-         -- Outbreak if Necrotic Plague is not fully stacked
-         if DKROT:CanUse("Outbreak") and DKROT:isOffCD("Outbreak") and npStacks <= 14 then
-            return "Outbreak"
-         end
-
-         -- Blood Tap if we can
-         if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 and DKROT:FullyDepletedRunes() > 0 then
-            return "Blood Tap"
-         end
-
-         -- Empower Rune Weapon if all runes are depleted and we are out of RP
-         if DKROT:CanUse("Empower Rune Weapon") and rp < 25 and DKROT:DepletedRunes() == 6 then
-            if DKROT:isOffCD("Empower Rune Weapon") and DKROT:BossOrPlayer("TARGET") then
-               return "Empower Rune Weapon"
-            end
-         end
-
-         -- If nothing else can be done
-         return nil
-      end,
-      AOERotation = function()
-         -- Rune Info
-         local frost, lfrost, fd = DKROT:RuneCDs(DKROT.SPECS.FROST)
-         local unholy, lunholy, ud = DKROT:RuneCDs(DKROT.SPECS.UNHOLY)
-         local blood, lblood, bd, lbd = DKROT:RuneCDs(DKROT.SPECS.BLOOD)
-         local death, tdeath = DKROT:DeathRunes()
-         local dFF, dBP = DKROT:GetDiseaseTime()
-         local bloodCharges = select(4, UnitBuff("player", DKROT.spells["Blood Charge"])) or 0
-         local rimeProc = select(7, UnitBuff("player", DKROT.spells["Freezing Fog"]))
-         local kmProc = select(7, UnitBuff("player", DKROT.spells["Killing Machine"]))
-         local rp = UnitPower("PLAYER")
-    
-         -- Horn of Winter
-         if DKROT_Settings.CD[DKROT.Current_Spec].UseHoW and DKROT:UseHoW() then
-            return "Horn of Winter"
-         end
-
-         -- Pillar of Frost on CD
-         if DKROT:CanUse("Pillar of Frost") and DKROT:isOffCD("Pillar of Frost") then
-            if DKROT:BossOrPlayer("TARGET") then
-               return "Pillar of Frost"
-            end
-         end
-
-         -- Frost Strike with Killing Machine
-         if kmProc and rp >= 25 then
-            return "Frost Strike"
-         end
-
-         -- Obliterate if we have an unholy rune
-         if DKROT:isOffCD("Obliterate") then
-             return "Obliterate"
-         end
-
-         -- Blood Boil
-         if dBP > 0 and DKROT:isOffCD("Blood Boil") then
-             return "Blood Boil"
-         end
-
-         -- Defile
-         if DKROT:HasTalent("Defile") and DKROT:isOffCD("Defile") then
-             return "Defile"
-         end
-
-         -- Howling Blast
-         if DKROT:isOffCD("Howling Blast") then
-             return "Howling Blast"
-         end
-
-         -- Blood Tap if we have more than 10 stacks
-         if DKROT:CanUse("Blood Tap") and bloodCharges >= 10 and DKROT:FullyDepletedRunes() > 0 then
-             return "Blood Tap"
-         end
-
-         -- Frost Strike with Killing Machine or Runic Power is above 88
-         if rp >= 88 then
-            return "Frost Strike"
-         end
-
-         -- Plague Strike if we're missing blood plague
-         if DKROT:isOffCD("Plague Strike") and dBP == 0 and lunholy == 0 then
-            return "Plague Strike"
-         end
-
-         -- Blood Tap if we have enough charges and depleted runes
-         if DKROT:CanUse("Blood Tap") and bloodCharges >= 5 and DKROT:FullyDepletedRunes() > 0 then
-             return "Blood Tap"
-         end
-
-         -- Frost Strike if possible
-         if rp >= 25 then
-             return "Frost Strike"
-         end
- 
-         -- Plague Leech when we have a fully depleted rune
-         if DKROT:CanUse("Plague Leech") and DKROT:isOffCD("Plague Leech") and DKROT:FullyDepletedRunes() >= 2 and dFF > 0 and dBP > 0 then
-            return "Plague Leech"
-         end
-
-         -- Plague Strike if we're missing blood plague
-         if DKROT:isOffCD("Plague Strike") and dBP == 0 and unholy == 0 then
-            return "Plague Strike"
-         end
-
-         -- Empower Rune Weapon if all runes are depleted and we are out of RP
-         if DKROT:CanUse("Empower Rune Weapon") and rp < 25 and DKROT:DepletedRunes() == 6 then
-            if DKROT:isOffCD("Empower Rune Weapon") and DKROT:BossOrPlayer("TARGET") then
-               return "Empower Rune Weapon"
-            end
-         end
-
-         -- If nothing else can be done
-         return nil
-      end
-   }
-
    DKROT_RegisterRotation(DKROT.SPECS.FROST, twohand)
    DKROT_RegisterRotation(DKROT.SPECS.FROST, dw_def)
-   DKROT_RegisterRotation(DKROT.SPECS.FROST, dw_np)
 
    -- Function to determine AOE rotation for Frost Spec
    function DKROT:FrostAOEMove()


### PR DESCRIPTION
Updates to both 2h and dw frost rotations
Added support for tracking Tier 18 2piece bonus in Cooldown Tracker, and integrated support into rotation
Removed Dual Wild - Necrotic Plague rotation as there are no real differences in the rotation itself based on the last SummonStone priority list before it shut down.