### PR TITLE
Active Target logic and rotation fixes

### DIFF
--- a/DKRot.toc
+++ b/DKRot.toc
@@ -1,6 +1,6 @@
 ## Interface: 60200
 ## Author: bunjiboys (Jardo@US-Kilrogg)
-## Version: 1.2.4
+## Version: 1.3.0
 ## Title: DKRot
 ## Notes: Death Knight Rotation assistance
 ## OptionalDeps: Masque
@@ -25,6 +25,7 @@ data.lua
 utils.lua
 ui.lua
 datadumper.lua
+events.lua
 
 # Rotation files
 rotations\blank.lua

--- a/UI/Options.xml
+++ b/UI/Options.xml
@@ -180,50 +180,7 @@
                </OnLoad>
             </Scripts>
          </Button>
-
-         <!-- Trans -->
-         <!--
-         <EditBox name="DKROT_FramePanel_NormalTrans" inherits="DKROT_EditBoxTemplate">
-            <Anchors>
-               <Anchor point="TOP" relativeTo="DKROT_FramePanel_ViewDD" relativePoint="BOTTOM" x="0" y="-5" />
-               <Anchor point="LEFT" relativeTo="DKROT_FramePanel_Locked" relativePoint="LEFT" x="10" />
-            </Anchors>
-            <Scripts>
-               <OnLoad>
-                  DKROT_FramePanel_NormalTrans_Text:SetText(DKROT_OPTIONS_FRAME_NORMALTRANS)
-               </OnLoad>
-            </Scripts>
-         </EditBox>
-         -->
-
-         <!--
-         <EditBox name="DKROT_FramePanel_Trans" inherits="DKROT_EditBoxTemplate">
-            <Anchors>
-               <Anchor point="TOP" relativeTo="DKROT_FramePanel_ViewDD" relativePoint="BOTTOM" x="0" y="-5" />
-               <Anchor point="LEFT" relativeTo="DKROT_FramePanel_Locked" relativePoint="LEFT" x="10" />
-            </Anchors>
-            <Scripts>
-               <OnLoad>
-                  DKROT_FramePanel_Trans_Text:SetText(DKROT_OPTIONS_FRAME_TRANS)
-               </OnLoad>
-            </Scripts>
-         </EditBox>
-         -->
          
-         <!-- Trans Combat -->
-         <!--
-         <EditBox name="DKROT_FramePanel_CombatTrans" inherits="DKROT_EditBoxTemplate">
-            <Anchors>
-               <Anchor point="TOPLEFT" relativeTo="DKROT_FramePanel_Trans" relativePoint="BOTTOMLEFT" x="0" y="-5" />
-            </Anchors>
-            <Scripts>
-               <OnLoad>
-                  DKROT_FramePanel_CombatTrans_Text:SetText(DKROT_OPTIONS_FRAME_COMBATTRANS)
-               </OnLoad>
-            </Scripts>
-         </EditBox>
-         -->
-
          <!-- Reset -->
          <Button name="DKROT_FramePanel_Reset" inherits="UIPanelButtonTemplate"  Text="DKROT_OPTIONS_RESET">
             <Size><AbsDimension x="120" y="22"/></Size>

--- a/events.lua
+++ b/events.lua
@@ -1,0 +1,109 @@
+-- vim: set ts=3 sw=3 foldmethod=indent:
+if select(2, UnitClass("player")) == "DEATHKNIGHT" then
+   local _, DKROT = ...
+
+   local function evtAddonLoaded(...)
+      local addonName = ...
+      if addonName == "DKRot" then
+         DKROT.MainFrame:UnregisterEvent("ADDON_LOADED")
+         if DKROT_Settings ~= nil and DKROT_Settings.UpdateWarning ~= true then
+            StaticPopup_Show("DKROT_UPDATE_WARNING")
+            DKROT_Settings.UpdateWarning = true
+         end
+      end
+   end
+
+   local function evtCombatLogEventUnfiltered(...)
+      local _, event, _, _, casterName, _, _,targetguid, targetName, _, _, _, spellName = ...
+      DKROT.curtime = GetTime()
+
+      if (event == "UNIT_DIED" or event == "UNIT_DESTROYED") and DKROT.DT.Unit[targetguid] ~= nil then
+         if DKROT.DT.Unit[targetguid].Frame ~= nil then
+            DKROT.DT.Unit[targetguid].Frame:SetAlpha(0)
+            DKROT.DT.Unit[targetguid].Frame = nil
+         end
+         DKROT.DT.Unit[targetguid] = nil
+      end
+
+      -- If we hit someone and its not a dot ticking, add / update time for the active
+      -- target tracking. Excluding spell_periodic_damage means we only track targets
+      -- actively being hit by our spells as dotted targets might be moved away
+      if casterName == DKROT.PLAYER_NAME and targetName ~= DKROT.PLAYER_NAME and (
+         (
+            event:endswith('_DAMAGE') or event:endswith('_AURA_APPLIED') or event:endswith('_AURA_REFRESH')
+         ) and event ~= 'SPELL_PERIODIC_DAMAGE'
+      ) then
+         DKROT.ActiveTargets.Targets[targetguid] = DKROT.curtime
+      end
+
+      if casterName == PLAYER_NAME and DKROT_Settings.DT.Dots[spellName] and targetName ~= PLAYER_NAME then
+         if (event == "SPELL_AURA_APPLIED" or event == "SPELL_AURA_REFRESH") then
+            if DKROT.DT.Unit[targetguid] == nil then
+               DKROT.DT.Unit[targetguid] = {}
+               DKROT.DT.Unit[targetguid].Spells = {}
+               DKROT.DT.Unit[targetguid].NumDots = 0
+               DKROT.DT.Unit[targetguid].Name = select(3, string.find(targetName, "(.-)-")) or targetName
+            end
+
+            if DKROT.DT.Unit[targetguid].Spells[spellName] == nil then
+               DKROT.DT.Unit[targetguid].NumDots = DKROT.DT.Unit[targetguid].NumDots + 1
+            end
+
+            if spellName == DKROT.spells["Death and Decay"] or spellName == DKROT.spells["Defile"] then
+               DKROT.DT.Unit[targetguid].Spells[spellName] = select(1, GetSpellCooldown(spellName)) + 10
+            else
+               DKROT.DT.Unit[targetguid].Spells[spellName] = select(7, UnitDebuff("TARGET", spellName))
+            end
+
+         elseif (event == "SPELL_AURA_REMOVED") then
+            if DKROT.DT.Unit[targetguid] ~= nil and  DKROT.DT.Unit[targetguid][spellName] ~= nil then
+                DKROT.DT.Unit[targetguid].Spells[spellName] = nil
+                DKROT.DT.Unit[targetguid].NumDots = DKROT.DT.Unit[targetguid].NumDots - 1
+            end
+         end
+      end
+   end
+
+   local function evtPlayerEnterCombat(...)
+      DKROT.TimeToDie.Targets = {}
+      DKROT.TimeToDie.Sweep = DKROT.curtime
+
+      DKROT.ActiveTargets.Targets = { }
+      DKROT.ActiveTargets.Sweep = DKROT.curtime
+   end
+
+   local function evtPlayerTalentChanged(...)
+      DKROT:CheckSpec()
+      DKROT:OptionsRefresh()
+
+      if evt == "ACTIVE_TALENT_GROUP_CHANGED" then
+         DKROT:CheckRotationTalents()
+      end
+   end
+
+   local function evtChatMsgAddon(...)
+      local prefix, message, channel, sender = ...
+      if prefix == "D4" then
+         local handler, time, name = ("\t"):split(message)
+         if handler == "PT" then
+            DKROT.PullTimer = GetTime() + tonumber(time)
+            DKROT:Debug("Received a DBM pull timer")
+         end
+      end
+   end
+
+   local events = {
+      ["ADDON_LOADED"] = evtAddonLoaded,
+      ["COMBAT_LOG_EVENT_UNFILTERED"]= evtCombatLogEventUnfiltered,
+      ["PLAYER_ENTER_COMBAT"] = evtPlayerEnterCombat,
+      ["PLAYER_TALENT_UPDATE"] = evtPlayerTalentChanged,
+      ["PLAYER_TALENT_GROUP_CHANGED"] = evtPlayerTalentChanged,
+      ["CHAT_MSG_ADDON"] = evtChatMsgAddon
+   }
+
+   function DKROT.EventHandler(self, evt, ...)
+      if evt == 'ADDON_LOADED' or (DKROT.loaded and events[evt] ~= nil) then
+         events[evt](...)
+      end
+   end
+end

--- a/init.lua
+++ b/init.lua
@@ -5,9 +5,12 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
    DKROT.debug = false
    DKROT.font = "Interface\\AddOns\\DKRot\\resources\\font.ttf"
 
+   DKROT.loaded = false
    DKROT.curtime = 0
    DKROT.GCD = 0
    DKROT.PullTimer = 0
+   DKROT.PLAYER_NAME = UnitName("player")
+   DKROT.PLAYER_RACE = select(2, UnitRace("player"))
 
    DKROT.ThreatMode = {
       Off = 0,
@@ -92,6 +95,12 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       {},
       {},
       {},
+   }
+
+   DKROT.ActiveTargets = {
+       Sweep = 0,
+       Targets = { },
+       LastUpdate = 0
    }
 
    DKROT.TimeToDie = {

--- a/utils.lua
+++ b/utils.lua
@@ -250,7 +250,7 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
                DKROT.TimeToDie.Targets[guid] = nil
             end
          end
-         DKROT.Sweep = GetTime()
+         DKROT.TimeToDie.Sweep = GetTime()
       end
 
       if target ~= nil and UnitCanAttack("PLAYER", "TARGET") then
@@ -787,6 +787,39 @@ if select(2, UnitClass("player")) == "DEATHKNIGHT" then
       end
 
       return false
+   end
+
+   function DKROT:GetActiveTargets()
+      local now = GetTime()
+
+      -- Cleanup old entries in the table
+      if (now - DKROT.ActiveTargets.Sweep) > 0.5 then
+         for guid, lastUpdate in pairs(DKROT.ActiveTargets.Targets) do
+            local tss = now - lastUpdate
+            if (now - lastUpdate) > (DKROT_Settings.ActiveTargetThreshold or 3) then
+               DKROT.ActiveTargets.Targets[guid] = nil
+            end
+         end
+
+         DKROT.ActiveTargets.Sweep = now
+      end
+
+      DKROT.ActiveTargets.LastUpdate = now
+      return tableSize(DKROT.ActiveTargets.Targets)
+   end
+
+   -- Utility function on string to check ending of string against keyword
+   function string.endswith(String, End)
+      return End == '' or string.sub(String, -string.len(End)) == End
+   end
+
+   function tableSize(t)
+       local cnt = 0
+       for obj in pairs(t) do
+           cnt = cnt + 1
+       end
+
+       return cnt
    end
 
    -- The base64 code below is courtesy of Alex Kloss (http://lua-users.org/wiki/BaseSixtyFour)


### PR DESCRIPTION
- Added logic to detect number of active targets
- Frost: Dual Wield
  - Another fix for excessive Obliterates.
  - Don't use Obliterate with Necrotic Plague unless its about to expire
  - Cleaned up logic around Plague Leech usage in general
  - Added DnD and Blood Boil usage based on target count
- Unholy: Necrotic Blight
  - Added support for pooling RP with Tier 18 4p before Dark Transformation drops off to quickly re-apply it
  - Fixed Blood Tap being suggested without any depleted runes
  - Added DnD and Blood Boil usage based on target count
